### PR TITLE
update conda link, fix pip caching, always upgrade mne

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2
 jobs:
     build_docs:
       docker:
-        # 3.6-jessie is too new for conda
-        - image: circleci/python:3.6-jessie
+        - image: circleci/python:3.6.8-stretch
       steps:
         - checkout
         - run:
@@ -14,11 +13,23 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
 
+        # Get environment.yml file to install MNE-Python
+        - run:
+            name: Get MNE-Python environment
+            command: |
+              curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
+
         # Load our data
         - restore_cache:
             keys:
               - data-cache-0
-              - pip-cache
+
+        # Load the python environment in a separate restore_cache call
+        # Note: This cannot be integrated with restore_cache above, because
+        # only the first matching key will be restored
+        - restore_cache:
+            keys:
+              - pip-cache-0-{{ checksum "environment.yml" }}
 
         - run:
             name: Spin up Xvfb
@@ -35,18 +46,20 @@ jobs:
         - run:
             name: Get Anaconda running
             command: |
-              wget -q http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+              wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
               chmod +x ~/miniconda.sh;
               ~/miniconda.sh -b -p ~/miniconda;
               export export PATH=~/miniconda/bin:$PATH;
               conda update --yes --quiet conda;
-              curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
               conda env create -f environment.yml
               source activate mne
+              pip install --upgrade mne
               python -c "import mne; mne.sys_info()"
 
+        # Save Python environment with a key based on the environment.yml that
+        # was downloaded from MNE-Python. If it changes, change the cache
         - save_cache:
-            key: pip-cache
+            key: pip-cache-0-{{ checksum "environment.yml"}}
             paths:
               - ~/.cache/pip
 


### PR DESCRIPTION
- Try stretch and python 3.6.8 docker image
- update link to install Miniconda (continuum is now Anaconda, and they provide miniconda3 or miniconda2, which is more explicit than "miniconda")
- Fix pip-caching:
    - the pip cache was never restored, because circle only restores the first matching key (see: [here](https://circleci.com/docs/2.0/caching/#restoring-cache)), thus only the data-cache was being restored
    - with a second `restore_cache` call, this should be fixed
    - I also make the pip-cache contingent on the upstream MNE-Python `environment.yml` ... in case there are changes upstream, we would want to update our cache ...
    - lastly: This involved also adding a `pip install -U mne`, because otherwise our cache might make us stuck with an older version of MNE-Python


