### PR TITLE
[WIP] import from config instead of whole module

### DIFF
--- a/01-import_and_filter.py
+++ b/01-import_and_filter.py
@@ -4,14 +4,13 @@
 ===========================
 
 The data are bandpass filtered to the frequencies defined in config.py
-(config.h_freq - config.l_freq Hz) using linear-phase fir filter with
-delay compensation.
+(h_freq - l_freq Hz) using linear-phase fir filter with delay compensation.
 The transition bandwidth is automatically defined. See
 `Background information on filtering
 <http://mne-tools.github.io/dev/auto_tutorials/plot_background_filtering.html>`_
-for more. The filtered data are saved to separate files to the subject's'MEG'
+for more. The filtered data are saved to separate files to the subject's 'MEG'
 directory.
-If config.plot = True plots raw data and power spectral density.
+If plot = True plots raw data and power spectral density.
 """  # noqa: E501
 
 import os.path as op
@@ -20,30 +19,33 @@ import mne
 from mne.parallel import parallel_func
 from warnings import warn
 
-import config
+from config import (meg_dir, runs, bads, base_fname, allow_maxshield,
+                    set_channel_types, rename_channels, h_freq, l_freq,
+                    l_trans_bandwidth, h_trans_bandwidth, resample_sfreq,
+                    plot, N_JOBS, subjects_list)
 
 
 def run_filter(subject):
     print("Processing subject: %s" % subject)
 
-    meg_subject_dir = op.join(config.meg_dir, subject)
+    meg_subject_dir = op.join(meg_dir, subject)
 
     n_raws = 0
-    for run in config.runs:
+    for run in runs:
 
         # read bad channels for run from config
         if run:
-            bads = config.bads[subject][run]
+            bads = bads[subject][run]  # noqa: F823
         else:
-            bads = config.bads[subject]
+            bads = bads[subject]
 
         extension = run + '_raw'
         raw_fname_in = op.join(meg_subject_dir,
-                               config.base_fname.format(**locals()))
+                               base_fname.format(**locals()))
 
         extension = run + '_filt_raw'
         raw_fname_out = op.join(meg_subject_dir,
-                                config.base_fname.format(**locals()))
+                                base_fname.format(**locals()))
 
         print("Input: ", raw_fname_in)
         print("Output: ", raw_fname_out)
@@ -54,36 +56,36 @@ def run_filter(subject):
             continue
 
         raw = mne.io.read_raw_fif(raw_fname_in,
-                                  allow_maxshield=config.allow_maxshield,
+                                  allow_maxshield=allow_maxshield,
                                   preload=True, verbose='error')
 
         # add bad channels
         raw.info['bads'] = bads
         print("added bads: ", raw.info['bads'])
 
-        if config.set_channel_types is not None:
-            raw.set_channel_types(config.set_channel_types)
-        if config.rename_channels is not None:
-            raw.rename_channels(config.rename_channels)
+        if set_channel_types is not None:
+            raw.set_channel_types(set_channel_types)
+        if rename_channels is not None:
+            raw.rename_channels(rename_channels)
 
         # Band-pass the data channels (MEG and EEG)
         print("Filtering data between %s and %s (Hz)" %
-              (config.l_freq, config.h_freq))
+              (l_freq, h_freq))
         raw.filter(
-            config.l_freq, config.h_freq,
-            l_trans_bandwidth=config.l_trans_bandwidth,
-            h_trans_bandwidth=config.h_trans_bandwidth,
+            l_freq, h_freq,
+            l_trans_bandwidth=l_trans_bandwidth,
+            h_trans_bandwidth=h_trans_bandwidth,
             filter_length='auto', phase='zero', fir_window='hamming',
             fir_design='firwin')
 
-        if config.resample_sfreq:
-            print("Resampling data to %.1f Hz" % config.resample_sfreq)
-            raw.resample(config.resample_sfreq, npad='auto')
+        if resample_sfreq:
+            print("Resampling data to %.1f Hz" % resample_sfreq)
+            raw.resample(resample_sfreq, npad='auto')
 
         raw.save(raw_fname_out, overwrite=True)
         n_raws += 1
 
-        if config.plot:
+        if plot:
             # plot raw data
             raw.plot(n_channels=50, butterfly=True, group_by='position')
 
@@ -95,5 +97,5 @@ def run_filter(subject):
         raise ValueError('No input raw data found.')
 
 
-parallel, run_func, _ = parallel_func(run_filter, n_jobs=config.N_JOBS)
-parallel(run_func(subject) for subject in config.subjects_list)
+parallel, run_func, _ = parallel_func(run_filter, n_jobs=N_JOBS)
+parallel(run_func(subject) for subject in subjects_list)

--- a/01-import_and_filter.py
+++ b/01-import_and_filter.py
@@ -35,9 +35,9 @@ def run_filter(subject):
 
         # read bad channels for run from config
         if run:
-            bads = bads[subject][run]  # noqa: F823
+            current_bads = bads[subject][run]
         else:
-            bads = bads[subject]
+            current_bads = bads[subject]
 
         extension = run + '_raw'
         raw_fname_in = op.join(meg_subject_dir,
@@ -60,7 +60,7 @@ def run_filter(subject):
                                   preload=True, verbose='error')
 
         # add bad channels
-        raw.info['bads'] = bads
+        raw.info['bads'] = current_bads
         print("added bads: ", raw.info['bads'])
 
         if set_channel_types is not None:


### PR DESCRIPTION
addresses #32 

I think that @jasmainak is right and that having imports in the form `from config import (X,Y,Z)` is more transparent as to which variables from `config.py` are getting used.

However, before continuing with this PR, I'd like to hear what @agramfort thinks about this and perhaps @larsoner and/or @massich 


Smaller question regarding coding style: Shouldn't the variables in `config.py` all be upper case, because they are constants?