### PR TITLE
RF: Do sensor-level group average via mne.grand_average()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
         - restore_cache:
             keys:
               - pip-cache-0
+              - data-cache-0
 
         - run:
             name: Get conda running
@@ -51,6 +52,11 @@ jobs:
             key: pip-cache-0
             paths:
               - ~/.cache/pip
+
+        - save_cache:
+            key: data-cache-0
+            paths:
+              - ~/mne_data/
 
         # Look at what we have and fail early if there is some library conflict
         - run:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pdf
 .DS_Store
 data
+.vscode

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -63,7 +63,9 @@ for subject in config.subjects_list:
         all_evokeds[idx].append(evoked)  # Insert to the container
 
 for idx, evokeds in all_evokeds.items():
-    all_evokeds[idx] = mne.grand_average(evokeds)  # Combine subjects
+    all_evokeds[idx] = mne.grand_average(
+        evokeds, interpolate_bads=config.interpolate_bads_grand_average
+    )  # Combine subjects
 
 
 extension = 'grand_average-ave'

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -63,7 +63,7 @@ for subject in config.subjects_list:
         all_evokeds[idx].append(evoked)  # Insert to the container
 
 for idx, evokeds in all_evokeds.items():
-    all_evokeds[idx] = mne.combine_evoked(evokeds, 'equal')  # Combine subjects
+    all_evokeds[idx] = mne.grand_average(evokeds)  # Combine subjects
 
 
 extension = 'grand_average-ave'

--- a/config.py
+++ b/config.py
@@ -534,6 +534,19 @@ ica_ctps_ecg_threshold = 0.1
 decoding_conditions = []
 # decoding_conditions = [('left', 'right')]
 
+###############################################################################
+# GROUP AVERAGE SENSORS
+# ---------------------
+#
+# ``interpolate_bads_grand_average`` : bool
+#    Interpolate or not missing sensors in `mne.grand_average`. It requires
+#    to have channel locations.
+#
+# Example
+# ~~~~~~~
+# >>> interpolate_bads_grand_average = True
+
+interpolate_bads_grand_average = True
 
 # ``decoding_metric`` : str
 #    The metric to use for cross-validation. It can be 'roc_auc' or 'accuracy'

--- a/config.py
+++ b/config.py
@@ -539,8 +539,10 @@ decoding_conditions = []
 # ---------------------
 #
 # ``interpolate_bads_grand_average`` : bool
-#    Interpolate or not missing sensors in `mne.grand_average`. It requires
-#    to have channel locations.
+#    Interpolate bad sensors in each dataset before calculating the grand
+#    average. This parameter is passed to the `mne.grand_average` function via
+#    the keyword argument `interpolate_bads`. It requires to have channel
+#    locations set.
 #
 # Example
 # ~~~~~~~

--- a/tests/configs/config_ds001810.py
+++ b/tests/configs/config_ds001810.py
@@ -23,3 +23,5 @@ use_ica = False
 
 subjects_list = ['01']
 sessions = ['anodalpre']
+
+interpolate_bads_grand_average = False

--- a/tests/configs/config_eeg_matchingpennies.py
+++ b/tests/configs/config_eeg_matchingpennies.py
@@ -18,3 +18,5 @@ conditions = ['left', 'right']
 decoding_conditions = [('left', 'right')]
 use_ssp = False
 use_ica = False
+
+interpolate_bads_grand_average = False


### PR DESCRIPTION
This works thanks to a fix in `mne-python:master` that will be included in 0.19: https://github.com/mne-tools/mne-python/pull/6711

So this PR should probably only be merged after `mne-python` 0.19 has been released?