### PR TITLE
BF: Extract the data rank from the info structure when estimating noise covariance

### DIFF
--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -57,7 +57,10 @@ def run_covariance(subject, session=None):
     epochs = mne.read_epochs(fname_epo, preload=True)
 
     print('  Computing regularized covariance')
-    cv = KFold(3, random_state=config.random_state, shuffle=True)
+    # Do not shuffle the data before splitting into train and test samples.
+    # Perform a block cross-validation instead to maintain autocorrelated
+    # noise.
+    cv = KFold(3, shuffle=False)
     cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', cv=cv,
                                  rank='info')
     cov.save(fname_cov)

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -57,8 +57,9 @@ def run_covariance(subject, session=None):
     epochs = mne.read_epochs(fname_epo, preload=True)
 
     print('  Computing regularized covariance')
-    cv = KFold(3, random_state=config.random_state)  # make cv deterministic
-    cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', cv=cv)
+    cv = KFold(3, random_state=config.random_state, shuffle=True)
+    cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', cv=cv,
+                                 rank='info')
     cov.save(fname_cov)
 
 

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -14,7 +14,6 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 from sklearn.model_selection import KFold
-import numpy as np
 
 import config
 
@@ -58,18 +57,6 @@ def run_covariance(subject, session=None):
     epochs = mne.read_epochs(fname_epo, preload=True)
 
     print('  Computing regularized covariance')
-    if isinstance(config.random_state, np.random.RandomState):
-        msg = (f'Using custom random number generator in cross-validation '
-               f'scheme: {config.random_state}')
-    elif config.random_state is not None:
-        msg = (f'Cross-validation random number generator will be seeded with '
-               f'the user-defined value: {config.random_state}')
-    else:
-        msg = 'Using random number generator with default settings'
-
-    print(msg)
-    del msg
-
     cv = KFold(3, random_state=config.random_state, shuffle=True)
     cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', cv=cv,
                                  rank='info')

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -14,6 +14,7 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 from sklearn.model_selection import KFold
+import numpy as np
 
 import config
 
@@ -57,6 +58,18 @@ def run_covariance(subject, session=None):
     epochs = mne.read_epochs(fname_epo, preload=True)
 
     print('  Computing regularized covariance')
+    if isinstance(config.random_state, np.random.RandomState):
+        msg = (f'Using custom random number generator in cross-validation '
+               f'scheme: {config.random_state}')
+    elif config.random_state is not None:
+        msg = (f'Cross-validation random number generator will be seeded with '
+               f'the user-defined value: {config.random_state}')
+    else:
+        msg = 'Using random number generator with default settings'
+
+    print(msg)
+    del msg
+
     cv = KFold(3, random_state=config.random_state, shuffle=True)
     cov = mne.compute_covariance(epochs, tmax=0, method='shrunk', cv=cv,
                                  rank='info')

--- a/config.py
+++ b/config.py
@@ -680,10 +680,7 @@ N_JOBS = 1
 # ``random_state`` : None | int | np.random.RandomState
 #    To specify the random generator state. This allows to have
 #    the results more reproducible between machines and systems.
-#    Some methods like ICA or the cross-validation scheme used in noise
-#    covariance estimation need random values for initialisation. Set to
-#    ``None`` if you do not wish to initialize the random number generator
-#    with a specific state.
+#    Some methods like ICA need random values for initialisation.
 
 random_state = 42
 

--- a/config.py
+++ b/config.py
@@ -680,7 +680,10 @@ N_JOBS = 1
 # ``random_state`` : None | int | np.random.RandomState
 #    To specify the random generator state. This allows to have
 #    the results more reproducible between machines and systems.
-#    Some methods like ICA need random values for initialisation.
+#    Some methods like ICA or the cross-validation scheme used in noise
+#    covariance estimation need random values for initialisation. Set to
+#    ``None`` if you do not wish to initialize the random number generator
+#    with a specific state.
 
 random_state = 42
 


### PR DESCRIPTION
<strike>- Shuffle the data before the cross-validation split. This is required to get any meaningful CV results.</strike>

- Extract the data rank from the `info` structure. At least on my  test data this was necessary to get correct results.

<strike>- Logging and documentation improvements</strike>