### PR TITLE
[needs discussion] ENH, TESTS: Improved filename sanitization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             name: test ds000246
             command: |
                export DS=ds000246
-               python tests/run_tests.py ${DS}
+               python tests/run_pipeline_tests.py ${DS}
                mkdir ~/reports/${DS}
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report.html ~/reports/${DS}/
                cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
@@ -103,7 +103,7 @@ jobs:
             name: test ds000248
             command: |
                export DS=ds000248
-               python tests/run_tests.py ${DS}
+               python tests/run_pipeline_tests.py ${DS}
                mkdir ~/reports/${DS}
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report.html ~/reports/${DS}/
                cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
@@ -112,7 +112,7 @@ jobs:
             name: test ds001810
             command: |
                export DS=ds001810
-               python tests/run_tests.py ${DS}
+               python tests/run_pipeline_tests.py ${DS}
                mkdir ~/reports/${DS}
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report.html ~/reports/${DS}/
                cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
@@ -121,7 +121,7 @@ jobs:
             name: test eeg_matchingpennies
             command: |
                export DS=eeg_matchingpennies
-               python tests/run_tests.py ${DS}
+               python tests/run_pipeline_tests.py ${DS}
                mkdir ~/reports/${DS}
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report.html ~/reports/${DS}/
                cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
@@ -130,10 +130,16 @@ jobs:
             name: test somato
             command: |
                export DS=somato
-               python tests/run_tests.py ${DS}
+               python tests/run_pipeline_tests.py ${DS}
                # mkdir ~/reports/${DS}
                # cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report.html ~/reports/${DS}/
                # cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
+
+        - run:
+            name: test modules
+            command: |
+               pip install pytest
+               pytest
 
         - store_artifacts:
             path: /home/circleci/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,6 @@ jobs:
               - data-cache-1
 
         - run:
-            name: test modules
-            command: |
-               pip install pytest
-               pytest
-
-        - run:
             name: Get conda running
             command: |
               wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
@@ -96,6 +90,12 @@ jobs:
                mkdir ~/reports
 
         # Run tests
+        - run:
+            name: test modules
+            command: |
+               pip install pytest
+               pytest
+
         - run:
             name: test ds000246
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             name: test modules
             command: |
                pip install pytest
-               pytest
+               pytest tests/
 
         - run:
             name: test ds000246

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,12 @@ jobs:
               - data-cache-1
 
         - run:
+            name: test modules
+            command: |
+               pip install pytest
+               pytest
+
+        - run:
             name: Get conda running
             command: |
               wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
@@ -134,12 +140,6 @@ jobs:
                # mkdir ~/reports/${DS}
                # cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report.html ~/reports/${DS}/
                # cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average.html ~/reports/${DS}/
-
-        - run:
-            name: test modules
-            command: |
-               pip install pytest
-               pytest
 
         - store_artifacts:
             path: /home/circleci/reports

--- a/10-time_frequency.py
+++ b/10-time_frequency.py
@@ -20,6 +20,8 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
+from pathtools import sanitize_filename
+
 
 freqs = np.arange(10, 40)
 n_cycles = freqs / 3.
@@ -67,11 +69,11 @@ def run_time_frequency(subject, session=None):
 
         power_fname_out = \
             op.join(fpath_deriv, bids_basename + '_power_%s-tfr.h5'
-                    % (condition.replace(op.sep, '')))
+                    % sanitize_filename(condition))
 
         itc_fname_out = \
             op.join(fpath_deriv, bids_basename + '_itc_%s-tfr.h5'
-                    % (condition.replace(op.sep, '')))
+                    % sanitize_filename(condition))
 
         power.save(power_fname_out, overwrite=True)
         itc.save(itc_fname_out, overwrite=True)

--- a/13-make_inverse.py
+++ b/13-make_inverse.py
@@ -16,6 +16,7 @@ from mne.minimum_norm import (make_inverse_operator, apply_inverse,
 from mne_bids import make_bids_basename
 
 import config
+from pathtools import sanitize_filename
 
 
 def run_inverse(subject, session=None):
@@ -70,7 +71,7 @@ def run_inverse(subject, session=None):
                             pick_ori=None)
         stc.save(op.join(fpath_deriv, '%s_%s_mne_dSPM_inverse-%s'
                          % (config.study_name, subject,
-                            condition.replace(op.sep, ''))))
+                            sanitize_filename(condition))))
 
 
 def main():

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -13,6 +13,7 @@ import mne
 from mne.parallel import parallel_func
 
 import config
+from pathtools import sanitize_filename
 
 
 def morph_stc(subject, session=None):
@@ -35,7 +36,7 @@ def morph_stc(subject, session=None):
     for condition in config.conditions:
         fname_stc = op.join(fpath_deriv, '%s_%s_mne_dSPM_inverse-%s'
                             % (config.study_name, subject,
-                               condition.replace(op.sep, '')))
+                               sanitize_filename(condition)))
         stc = mne.read_source_estimate(fname_stc)
 
         morph = mne.compute_source_morph(stc, subject_from=subject,

--- a/pathtools.py
+++ b/pathtools.py
@@ -1,0 +1,34 @@
+import re
+
+
+def sanitize_filename(fname):
+    """Sanitize the a filename.
+
+    Allowed characters in a file name are: ``A-Z``, ``a-z``, ``0-9``, ``-``,
+    ``_``, and ``.``. All non-allowed characters (including spaces) are
+    replaced with an underscore.
+
+    Parameters
+    ----------
+    fname : str or path-like
+        The filename to sanitize.
+
+    Returns
+    -------
+    sanitized_fname : str
+        The sanitized filename.
+
+    Raises
+    ------
+    ValueError
+        If nothing's left after sanitization.
+    """
+    fname = str(fname)
+    sanitized_fname = re.sub(r'[^\w\-_\.]', '', fname)
+
+    if not sanitized_fname:
+        msg = ('No filename left after sanitization! Please reconsider your '
+               'naming scheme.')
+        raise ValueError(msg)
+
+    return sanitized_fname

--- a/pathtools.py
+++ b/pathtools.py
@@ -6,7 +6,7 @@ def sanitize_filename(fname):
 
     Allowed characters in a file name are: ``A-Z``, ``a-z``, ``0-9``, ``-``,
     ``_``, and ``.``. All non-allowed characters (including spaces) are
-    replaced with an underscore.
+    removed.
 
     Parameters
     ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+addopts = -rA

--- a/tests/run_pipeline_tests.py
+++ b/tests/run_pipeline_tests.py
@@ -73,7 +73,7 @@ TEST_SUITE = {
 }
 
 
-def run_tests(test_suite):
+def run_pipeline_tests(test_suite):
     """Run a suite of tests.
 
     Parameters
@@ -132,4 +132,4 @@ if __name__ == '__main__':
     print('Running the following tests: {}'
           .format(', '.join(test_suite.keys())))
 
-    run_tests(test_suite)
+    run_pipeline_tests(test_suite)

--- a/tests/test_pathtools.py
+++ b/tests/test_pathtools.py
@@ -1,0 +1,21 @@
+import sys
+sys.path.insert(0, '..')
+
+import pytest  # noqa:E402
+from pathtools import sanitize_filename
+
+
+@pytest.mark.parametrize(
+    ('input_fname', 'expected_sanitized_fname', 'should_raise'),
+    [('all_good_here', 'all_good_here', False),
+     ('please/sanitize', 'pleasesanitize', False),
+     ('we-are_all.allowed-123ABC', 'we-are_all.allowed-123ABC', False),
+     (r':\/,#?=+()*^%$@!<>^', None, True)])
+def test_sanitize_filename(input_fname, expected_sanitized_fname,
+                           should_raise):
+    if should_raise:
+        with pytest.raises(ValueError, match='No filename left'):
+            sanitized_fname = sanitize_filename(input_fname)
+    else:
+        sanitized_fname = sanitize_filename(input_fname)
+        assert sanitized_fname == expected_sanitized_fname


### PR DESCRIPTION
This PR adds improved sanitization for filenames. Previously, we would only remove `os.sep` from filenames; however, this is not the only invalid character, and also it's OS-dependent. To ensure filenames are compatible with different operating systems, we have
to apply much stricter rules.

I have added a module `pathtools.py` that contains a `sanitize_filename` function, which removes all non-alphanumeric characters (except `-`, `_`, and `.`) from a filename. Having the sanitization done in a single place also allows for easy adjustment. For example, I personally would  prefer to replace invalid characters with `_`; but the current implementation was designed such that it would resemble the behavior of the existing code.

To test this module, I have also enabled pytest on our CI system.