### PR TITLE
MRG: Allow specification of root path in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,11 +16,21 @@ PIPELINE_NAME = 'mne-study-template'
 VERSION = '0.1.dev0'
 CODE_URL = 'https://github.com/mne-tools/mne-study-template'
 
-# Get the bids_root from an environment variable, raise an error if not found
-bids_root = os.getenv('BIDS_ROOT', False)
+# Speficy the BIDS root directory. Pass an empty string or `None` to use the
+# value specified in the ``BIDS_ROOT`` environment variable instead. Raises
+# an exception if the BIDS root has not been specified.
+#
+# bids_root = '/path/to/your/bids_root'  # Use this to specify a path here.
+bids_root = None  # Make use of the ``BIDS_ROOT`` environment variable.
+
 if not bids_root:
-    raise RuntimeError('You need to define an environment variable '
-                       '`BIDS_ROOT` pointing to the root of your BIDS dataset')
+    # Extract value from environment variable.
+    bids_root = os.getenv('BIDS_ROOT', False)
+    if not bids_root:
+        msg = ('You need to specify `bids_root` in config.py or define an '
+               'environment variable `BIDS_ROOT` pointing to the root of your '
+               'BIDS dataset')
+        raise ValueError(msg)
 
 
 # ``subjects_dir`` : str

--- a/config.py
+++ b/config.py
@@ -18,9 +18,9 @@ CODE_URL = 'https://github.com/mne-tools/mne-study-template'
 
 
 # ``bids_root`` : str or None
-#   Speficy the BIDS root directory. Pass an empty string or `None` to use the
-#   value specified in the ``BIDS_ROOT`` environment variable instead. Raises
-#   an exception if the BIDS root has not been specified.
+#   Speficy the BIDS root directory. Pass an empty string or ```None`` to use
+#   the value specified in the ``BIDS_ROOT`` environment variable instead.
+#   Raises an exception if the BIDS root has not been specified.
 #
 # Example
 # ~~~~~~~

--- a/config.py
+++ b/config.py
@@ -16,12 +16,19 @@ PIPELINE_NAME = 'mne-study-template'
 VERSION = '0.1.dev0'
 CODE_URL = 'https://github.com/mne-tools/mne-study-template'
 
-# Speficy the BIDS root directory. Pass an empty string or `None` to use the
-# value specified in the ``BIDS_ROOT`` environment variable instead. Raises
-# an exception if the BIDS root has not been specified.
+
+# ``bids_root`` : str or None
+#   Speficy the BIDS root directory. Pass an empty string or `None` to use the
+#   value specified in the ``BIDS_ROOT`` environment variable instead. Raises
+#   an exception if the BIDS root has not been specified.
 #
-# bids_root = '/path/to/your/bids_root'  # Use this to specify a path here.
-bids_root = None  # Make use of the ``BIDS_ROOT`` environment variable.
+# Example
+# ~~~~~~~
+# >>> bids_root = '/path/to/your/bids_root'  # Use this to specify a path here.
+# or
+# >>> bids_root = None  # Make use of the ``BIDS_ROOT`` environment variable.
+
+bids_root = None
 
 if not bids_root:
     # Extract value from environment variable.


### PR DESCRIPTION
The BIDS root directory could previously only be specified using the environment variable `BIDS_ROOT`. However, users told me this is cumbersome and doesn't really align with what they're used to in their daily work. This commit makes it obvious how to specify a BIDS root path
directly in `config.py`. By default, we will continue to use `BIDS_ROOT` environment variable, but it should now be easy for users to change this behavior.

Also raises a `ValueError` now instead of a `RuntimeError` if no BIDS root has been specified, I think this is more appropriate here.

Let me know what you think – haven't added tests yet because I first wanted to hear your thoughts on this one.