### PR TITLE
MRG: BF: Sanitize paths in group-average analysis

### DIFF
--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -44,7 +44,8 @@ def morph_stc(subject, session=None):
         stc_fsaverage = morph.apply(stc)
         stc_fsaverage.save(
             op.join(fpath_deriv,
-                    'mne_dSPM_inverse_fsaverage-%s' % condition))
+                    'mne_dSPM_inverse_fsaverage-%s'
+                    % condition.replace(op.sep, '')))
         morphed_stcs.append(stc_fsaverage)
 
     return morphed_stcs
@@ -66,7 +67,8 @@ def main():
         this_stc /= len(all_morphed_stcs)
         this_stc.save(op.join(config.bids_root, 'derivatives',
                               config.PIPELINE_NAME,
-                              'average_dSPM-%s' % condition))
+                              'average_dSPM-%s'
+                              % condition.replace(op.sep, '')))
 
 
 if __name__ == '__main__':

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -75,7 +75,7 @@ def run_report(subject, session=None):
 
         for evoked in evokeds:
             fname = op.join(fpath_deriv, 'mne_dSPM_inverse-%s'
-                            % evoked.comment)
+                            % evoked.comment.replace(op.sep, ''))
             stc = mne.read_source_estimate(fname, subject)
             brain = stc.plot(views=['lat'], hemi='both')
 
@@ -109,7 +109,7 @@ def main():
 
         stc_fname = op.join(config.bids_root, 'derivatives',
                             config.PIPELINE_NAME,
-                            'average_dSPM-%s' % condition)
+                            'average_dSPM-%s' % condition.replace(op.sep, ''))
         if op.exists(stc_fname + "-lh.stc"):
             stc = mne.read_source_estimate(stc_fname, subject='fsaverage')
             brain = stc.plot(views=['lat'], hemi='both', subject='fsaverage',


### PR DESCRIPTION
This analysis step would fail for me if the condition names contains a forward slash. Need to sanitize the generated filenames.