### PR TITLE
MRG: ENH: Allow specification of custom config file

### DIFF
--- a/config.py
+++ b/config.py
@@ -722,9 +722,23 @@ allow_maxshield = True
 # For example `export MNE_BIDS_STUDY_CONFIG=config_eeg_matchingpennies`
 
 if "MNE_BIDS_STUDY_CONFIG" in os.environ:
-    cfg_name = os.environ['MNE_BIDS_STUDY_CONFIG']
-    cfg_path = 'tests.configs.{}'.format(cfg_name)
-    custom_cfg = importlib.import_module(cfg_path)
+    cfg_path = os.environ['MNE_BIDS_STUDY_CONFIG']
+
+    if os.path.exists(cfg_path):
+        print('Using custom configuration specified in MNE_BIDS_STUDY_CONFIG.')
+    else:
+        msg = ('The custom configuration file specified in the '
+               'MNE_BIDS_STUDY_CONFIG environment variable could not be '
+               'found: {cfg_path}'.format(cfg_path=cfg_path))
+        raise ValueError(msg)
+
+    # Import configuration from an arbitrary path without having to fiddle
+    # with `sys.path`.
+    spec = importlib.util.spec_from_file_location(name='custom_config',
+                                                  location=cfg_path)
+    custom_cfg = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(custom_cfg)
+    del spec
 
     new = None
     for val in dir(custom_cfg):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,7 +6,8 @@ import argparse
 import importlib
 
 # Add the pipelines dir to the PATH
-sys.path.append(op.join(op.dirname(__file__), '..'))
+pipeline_dir = os.path.abspath(op.join(op.dirname(__file__), '..'))
+sys.path.append(pipeline_dir)
 
 
 def fetch(dataset=None):
@@ -92,7 +93,12 @@ def run_tests(test_suite):
         # export the environment variables
         os.environ['DATASET'] = dataset
         os.environ['BIDS_ROOT'] = op.join(DATA_DIR, dataset)
-        os.environ['MNE_BIDS_STUDY_CONFIG'] = test_tuple[0]
+
+        config_name = test_tuple[0]
+        config_path = os.path.join(pipeline_dir, 'tests', 'configs',
+                                   config_name + '.py')
+        os.environ['MNE_BIDS_STUDY_CONFIG'] = config_path
+        del config_name, config_path
 
         # Fetch the data
         fetch(dataset)


### PR DESCRIPTION
This used to only work with our CI tests, but now users can set `MNE_BIDS_STUDY_CONFIG` to an arbitrary pathand use the configuration from that file. Tests were updated to pass the absolute path of the requested test config.

Closes #83.