### PR TITLE
MRG: BF: Respect config.allow_maxshield when reading raw data

### DIFF
--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -114,7 +114,13 @@ def run_maxwell_filter(subject, session=None):
         # - sets channels types according to BIDS channels.tsv `type` column
         # - sets raw.annotations using the BIDS events.tsv
         _, bids_fname = op.split(bids_fpath)
-        raw = read_raw_bids(bids_fname, config.bids_root)
+
+        extra_params = dict()
+        if config.allow_maxshield:
+            extra_params['allow_maxshield'] = config.allow_maxshield
+
+        raw = read_raw_bids(bids_fname, config.bids_root,
+                            extra_params=extra_params)
 
         # XXX hack to deal with dates that fif files cannot handle
         if config.daysback is not None:

--- a/config.py
+++ b/config.py
@@ -740,7 +740,7 @@ shortest_event = 1
 #    To import data that was recorded with Maxshield on before running
 #    maxfilter set this to True.
 
-allow_maxshield = True
+allow_maxshield = False
 
 ###############################################################################
 # Overwrite with custom config options


### PR DESCRIPTION
This also sets `allow_maxfilter=False` by default, as some `mne-bids` reader functions do not support this kwarg and would fail if it is passed.