### PR TITLE
BF: Fixes for using custom config

### DIFF
--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -216,7 +216,7 @@ def main():
     parallel, run_func, _ = parallel_func(run_maxwell_filter,
                                           n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -55,7 +55,7 @@ def run_maxwell_filter(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
     data_dir = op.join(config.bids_root, subject_path)
 
     for run_idx, run in enumerate(config.get_runs()):
@@ -70,7 +70,8 @@ def run_maxwell_filter(subject, session=None):
                                            space=config.space
                                            )
         # Find the data file
-        search_str = op.join(data_dir, bids_basename) + '_' + config.kind + '*'
+        search_str = op.join(data_dir,
+                             bids_basename) + '_' + config.get_kind() + '*'
         fnames = sorted(glob.glob(search_str))
         fnames = [f for f in fnames
                   if op.splitext(f)[1] in mne_bids_readers]

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -62,7 +62,7 @@ def run_maxwell_filter(subject, session=None):
 
         bids_basename = make_bids_basename(subject=subject,
                                            session=session,
-                                           task=config.task,
+                                           task=config.get_task(),
                                            acquisition=config.acq,
                                            run=run,
                                            processing=config.proc,

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -58,7 +58,7 @@ def run_maxwell_filter(subject, session=None):
     subject_path = op.join(subject_path, config.kind)
     data_dir = op.join(config.bids_root, subject_path)
 
-    for run_idx, run in enumerate(config.runs):
+    for run_idx, run in enumerate(config.get_runs()):
 
         bids_basename = make_bids_basename(subject=subject,
                                            session=session,
@@ -216,7 +216,7 @@ def main():
     parallel, run_func, _ = parallel_func(run_maxwell_filter,
                                           n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -96,8 +96,8 @@ def main():
     """Run filter."""
     parallel, run_func, _ = parallel_func(run_filter, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.runs,
-                               config.sessions))
+             itertools.product(config.subjects_list, config.get_runs(),
+                               config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -96,7 +96,7 @@ def main():
     """Run filter."""
     parallel, run_func, _ = parallel_func(run_filter, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.get_runs(),
+             itertools.product(config.get_subjects(), config.get_runs(),
                                config.get_sessions()))
 
 

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -37,7 +37,7 @@ def run_filter(subject, run=None, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -41,7 +41,7 @@ def run_filter(subject, run=None, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=run,
                                        processing=config.proc,

--- a/03-extract_events.py
+++ b/03-extract_events.py
@@ -50,7 +50,7 @@ def run_events(subject, run=None, session=None):
                           config.PIPELINE_NAME, subject_path)
 
     raw_fname_in = \
-            op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+        op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
 
     eve_fname_out = op.join(fpath_deriv, bids_basename + '-eve.fif')
 
@@ -79,8 +79,8 @@ def main():
     """Run events."""
     parallel, run_func, _ = parallel_func(run_events, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.runs,
-                               config.sessions))
+             itertools.product(config.subjects_list, config.get_runs(),
+                               config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/03-extract_events.py
+++ b/03-extract_events.py
@@ -79,7 +79,7 @@ def main():
     """Run events."""
     parallel, run_func, _ = parallel_func(run_events, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.get_runs(),
+             itertools.product(config.get_subjects(), config.get_runs(),
                                config.get_sessions()))
 
 

--- a/03-extract_events.py
+++ b/03-extract_events.py
@@ -37,7 +37,7 @@ def run_events(subject, run=None, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=run,
                                        processing=config.proc,

--- a/03-extract_events.py
+++ b/03-extract_events.py
@@ -33,7 +33,7 @@ def run_events(subject, run=None, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/04-make_epochs.py
+++ b/04-make_epochs.py
@@ -40,7 +40,7 @@ def run_epochs(subject, session=None):
 
     subject_path = op.join(subject_path, config.kind)
 
-    for run_idx, run in enumerate(config.runs):
+    for run_idx, run in enumerate(config.get_runs()):
 
         bids_basename = make_bids_basename(subject=subject,
                                            session=session,
@@ -56,7 +56,7 @@ def run_epochs(subject, session=None):
                               config.PIPELINE_NAME, subject_path)
 
         raw_fname_in = \
-                op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+            op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
 
         print("Input: ", raw_fname_in)
 
@@ -123,7 +123,7 @@ def main():
     # Here we use fewer N_JOBS to prevent potential memory problems
     parallel, run_func, _ = parallel_func(run_epochs, n_jobs=N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/04-make_epochs.py
+++ b/04-make_epochs.py
@@ -123,7 +123,7 @@ def main():
     # Here we use fewer N_JOBS to prevent potential memory problems
     parallel, run_func, _ = parallel_func(run_epochs, n_jobs=N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/04-make_epochs.py
+++ b/04-make_epochs.py
@@ -44,7 +44,7 @@ def run_epochs(subject, session=None):
 
         bids_basename = make_bids_basename(subject=subject,
                                            session=session,
-                                           task=config.task,
+                                           task=config.get_task(),
                                            acquisition=config.acq,
                                            run=run,
                                            processing=config.proc,
@@ -100,7 +100,7 @@ def run_epochs(subject, session=None):
     print('  Writing epochs to disk')
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/04-make_epochs.py
+++ b/04-make_epochs.py
@@ -38,7 +38,7 @@ def run_epochs(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     for run_idx, run in enumerate(config.get_runs()):
 
@@ -80,7 +80,7 @@ def run_epochs(subject, session=None):
     elif 'mag' in config.ch_types:
         meg = 'mag'
 
-    eeg = 'eeg' in config.ch_types or config.kind == 'eeg'
+    eeg = config.get_kind() == 'eeg'
 
     picks = mne.pick_types(raw.info, meg=meg, eeg=eeg, stim=True,
                            eog=True, exclude=())

--- a/04-make_epochs.py
+++ b/04-make_epochs.py
@@ -95,7 +95,7 @@ def run_epochs(subject, session=None):
     epochs = mne.Epochs(raw, events, event_id, config.tmin, config.tmax,
                         proj=True, picks=picks, baseline=config.baseline,
                         preload=False, decim=config.decim,
-                        reject=config.reject)
+                        reject=config.get_reject())
 
     print('  Writing epochs to disk')
     bids_basename = make_bids_basename(subject=subject,

--- a/05a-run_ica.py
+++ b/05a-run_ica.py
@@ -163,7 +163,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(run_ica, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/05a-run_ica.py
+++ b/05a-run_ica.py
@@ -46,7 +46,7 @@ def run_ica(subject, session=None):
 
         bids_basename = make_bids_basename(subject=subject,
                                            session=session,
-                                           task=config.task,
+                                           task=config.get_task(),
                                            acquisition=config.acq,
                                            run=run,
                                            processing=config.proc,

--- a/05a-run_ica.py
+++ b/05a-run_ica.py
@@ -77,7 +77,7 @@ def run_ica(subject, session=None):
 
     # don't reject based on EOG to keep blink artifacts
     # in the ICA computation.
-    reject_ica = config.reject
+    reject_ica = config.get_reject()
     if reject_ica and 'eog' in reject_ica:
         reject_ica = dict(reject_ica)
         del reject_ica['eog']

--- a/05a-run_ica.py
+++ b/05a-run_ica.py
@@ -40,7 +40,7 @@ def run_ica(subject, session=None):
     raw_list = list()
     print("  Loading raw data")
 
-    for run in config.runs:
+    for run in config.get_runs():
         # load first run of raw data for ecg /eog epochs
         print("  Loading one run from raw data")
 
@@ -163,7 +163,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(run_ica, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/05b-run_ssp.py
+++ b/05b-run_ssp.py
@@ -85,7 +85,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(run_ssp, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/05b-run_ssp.py
+++ b/05b-run_ssp.py
@@ -29,7 +29,7 @@ def run_ssp(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     # compute SSP on first run of raw
     run = config.get_runs()[0]

--- a/05b-run_ssp.py
+++ b/05b-run_ssp.py
@@ -36,7 +36,7 @@ def run_ssp(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=run,
                                        processing=config.proc,
@@ -54,7 +54,7 @@ def run_ssp(subject, session=None):
     # when saving proj, use bids_basename=None
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/05b-run_ssp.py
+++ b/05b-run_ssp.py
@@ -32,7 +32,7 @@ def run_ssp(subject, session=None):
     subject_path = op.join(subject_path, config.kind)
 
     # compute SSP on first run of raw
-    run = config.runs[0]
+    run = config.get_runs()[0]
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -85,7 +85,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(run_ssp, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/06a-apply_ica.py
+++ b/06a-apply_ica.py
@@ -228,7 +228,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(apply_ica, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.get_runs(),
+             itertools.product(config.get_subjects(), config.get_runs(),
                                config.get_sessions()))
 
 

--- a/06a-apply_ica.py
+++ b/06a-apply_ica.py
@@ -69,7 +69,7 @@ def apply_ica(subject, run, session):
                                        session=session,
                                        task=config.task,
                                        acquisition=config.acq,
-                                       run=config.runs[0],
+                                       run=config.get_runs()[0],
                                        processing=config.proc,
                                        recording=config.rec,
                                        space=config.space
@@ -228,8 +228,8 @@ def main():
         return
     parallel, run_func, _ = parallel_func(apply_ica, n_jobs=config.N_JOBS)
     parallel(run_func(subject, run, session) for subject, run, session in
-             itertools.product(config.subjects_list, config.runs,
-                               config.sessions))
+             itertools.product(config.subjects_list, config.get_runs(),
+                               config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/06a-apply_ica.py
+++ b/06a-apply_ica.py
@@ -36,7 +36,7 @@ def apply_ica(subject, run, session):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/06a-apply_ica.py
+++ b/06a-apply_ica.py
@@ -40,7 +40,7 @@ def apply_ica(subject, run, session):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
@@ -67,7 +67,7 @@ def apply_ica(subject, run, session):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=config.get_runs()[0],
                                        processing=config.proc,

--- a/06a-apply_ica.py
+++ b/06a-apply_ica.py
@@ -93,7 +93,6 @@ def apply_ica(subject, run, session):
 
     for ch_type in config.ch_types:
         report = None
-        print(ch_type)
         picks = all_picks[ch_type]
 
         # Load ICA

--- a/06b-apply_ssp.py
+++ b/06b-apply_ssp.py
@@ -72,7 +72,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(apply_ssp, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/06b-apply_ssp.py
+++ b/06b-apply_ssp.py
@@ -29,7 +29,7 @@ def apply_ssp(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/06b-apply_ssp.py
+++ b/06b-apply_ssp.py
@@ -72,7 +72,7 @@ def main():
         return
     parallel, run_func, _ = parallel_func(apply_ssp, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/06b-apply_ssp.py
+++ b/06b-apply_ssp.py
@@ -33,7 +33,7 @@ def apply_ssp(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/07-make_evoked.py
+++ b/07-make_evoked.py
@@ -79,7 +79,7 @@ def main():
     """Run evoked."""
     parallel, run_func, _ = parallel_func(run_evoked, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/07-make_evoked.py
+++ b/07-make_evoked.py
@@ -30,7 +30,7 @@ def run_evoked(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/07-make_evoked.py
+++ b/07-make_evoked.py
@@ -79,7 +79,7 @@ def main():
     """Run evoked."""
     parallel, run_func, _ = parallel_func(run_evoked, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/07-make_evoked.py
+++ b/07-make_evoked.py
@@ -26,7 +26,7 @@ def run_evoked(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -32,7 +32,7 @@ for subject in config.get_subjects():
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -23,12 +23,8 @@ if config.get_sessions():
 else:
     session = None
 
-for subject in config.subjects_list:
-    if subject in config.exclude_subjects:
-        print("Ignoring subject: %s" % subject)
-        continue
-    else:
-        print("Processing subject: %s" % subject)
+for subject in config.get_subjects():
+    print("Processing subject: %s" % subject)
 
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -18,7 +18,10 @@ import config
 all_evokeds = defaultdict(list)
 
 # XXX to fix
-session = config.sessions[0]
+if config.get_sessions():
+    session = config.get_sessions()[0]
+else:
+    session = None
 
 for subject in config.subjects_list:
     if subject in config.exclude_subjects:

--- a/08-group_average_sensors.py
+++ b/08-group_average_sensors.py
@@ -36,7 +36,7 @@ for subject in config.get_subjects():
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/09-sliding_estimator.py
+++ b/09-sliding_estimator.py
@@ -98,7 +98,7 @@ def main():
     """Run sliding estimator."""
     # Here we go parallel inside the :class:`mne.decoding.SlidingEstimator`
     # so we don't dispatch manually to multiple jobs.
-    for subject in config.subjects_list:
+    for subject in config.get_subjects():
         for session in config.get_sessions():
             for conditions in config.decoding_conditions:
                 run_time_decoding(subject, *conditions, session=session)

--- a/09-sliding_estimator.py
+++ b/09-sliding_estimator.py
@@ -48,7 +48,7 @@ def run_time_decoding(subject, condition1, condition2, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/09-sliding_estimator.py
+++ b/09-sliding_estimator.py
@@ -99,7 +99,7 @@ def main():
     # Here we go parallel inside the :class:`mne.decoding.SlidingEstimator`
     # so we don't dispatch manually to multiple jobs.
     for subject in config.subjects_list:
-        for session in config.sessions:
+        for session in config.get_sessions():
             for conditions in config.decoding_conditions:
                 run_time_decoding(subject, *conditions, session=session)
 

--- a/09-sliding_estimator.py
+++ b/09-sliding_estimator.py
@@ -44,7 +44,7 @@ def run_time_decoding(subject, condition1, condition2, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/10-time_frequency.py
+++ b/10-time_frequency.py
@@ -82,7 +82,7 @@ def main():
     parallel, run_func, _ = parallel_func(run_time_frequency,
                                           n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/10-time_frequency.py
+++ b/10-time_frequency.py
@@ -34,7 +34,7 @@ def run_time_frequency(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/10-time_frequency.py
+++ b/10-time_frequency.py
@@ -82,7 +82,7 @@ def main():
     parallel, run_func, _ = parallel_func(run_time_frequency,
                                           n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/10-time_frequency.py
+++ b/10-time_frequency.py
@@ -38,7 +38,7 @@ def run_time_frequency(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/11-make_forward.py
+++ b/11-make_forward.py
@@ -110,7 +110,7 @@ def main():
     """Run forward."""
     parallel, run_func, _ = parallel_func(run_forward, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/11-make_forward.py
+++ b/11-make_forward.py
@@ -28,7 +28,7 @@ def run_forward(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -68,7 +68,8 @@ def run_forward(subject, session=None):
                                        )
 
     data_dir = op.join(config.bids_root, subject_path)
-    search_str = op.join(data_dir, bids_basename) + '_' + config.kind + '*'
+    search_str = (op.join(data_dir, bids_basename) + '_' +
+                  config.get_kind() + '*')
     fnames = sorted(glob.glob(search_str))
     fnames = [f for f in fnames
               if op.splitext(f)[1] in mne_bids_readers]
@@ -92,7 +93,7 @@ def run_forward(subject, session=None):
     evoked = mne.read_evokeds(fname_evoked, condition=0)
 
     # Here we only use 3-layers BEM only if EEG is available.
-    if 'eeg' in config.ch_types or config.kind == 'eeg':
+    if config.get_kind() == 'eeg':
         model = mne.make_bem_model(subject, ico=4,
                                    conductivity=(0.3, 0.006, 0.3),
                                    subjects_dir=config.subjects_dir)

--- a/11-make_forward.py
+++ b/11-make_forward.py
@@ -32,7 +32,7 @@ def run_forward(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
@@ -59,7 +59,7 @@ def run_forward(subject, session=None):
     # XXX : maybe simplify
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=config.get_runs()[0],
                                        processing=config.proc,

--- a/11-make_forward.py
+++ b/11-make_forward.py
@@ -87,7 +87,7 @@ def run_forward(subject, session=None):
     mne.write_trans(fname_trans, trans)
 
     src = mne.setup_source_space(subject, spacing=config.spacing,
-                                 subjects_dir=config.subjects_dir,
+                                 subjects_dir=config.get_subjects_dir(),
                                  add_dist=False)
 
     evoked = mne.read_evokeds(fname_evoked, condition=0)
@@ -96,10 +96,10 @@ def run_forward(subject, session=None):
     if config.get_kind() == 'eeg':
         model = mne.make_bem_model(subject, ico=4,
                                    conductivity=(0.3, 0.006, 0.3),
-                                   subjects_dir=config.subjects_dir)
+                                   subjects_dir=config.get_subjects_dir())
     else:
         model = mne.make_bem_model(subject, ico=4, conductivity=(0.3,),
-                                   subjects_dir=config.subjects_dir)
+                                   subjects_dir=config.get_subjects_dir())
 
     bem = mne.make_bem_solution(model)
     fwd = mne.make_forward_solution(evoked.info, trans, src, bem,

--- a/11-make_forward.py
+++ b/11-make_forward.py
@@ -61,7 +61,7 @@ def run_forward(subject, session=None):
                                        session=session,
                                        task=config.task,
                                        acquisition=config.acq,
-                                       run=config.runs[0],
+                                       run=config.get_runs()[0],
                                        processing=config.proc,
                                        recording=config.rec,
                                        space=config.space
@@ -110,7 +110,7 @@ def main():
     """Run forward."""
     parallel, run_func, _ = parallel_func(run_forward, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -70,7 +70,7 @@ def main():
     """Run cov."""
     parallel, run_func, _ = parallel_func(run_covariance, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -26,7 +26,7 @@ def run_covariance(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -30,7 +30,7 @@ def run_covariance(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/12-make_cov.py
+++ b/12-make_cov.py
@@ -70,7 +70,7 @@ def main():
     """Run cov."""
     parallel, run_func, _ = parallel_func(run_covariance, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/13-make_inverse.py
+++ b/13-make_inverse.py
@@ -85,7 +85,7 @@ def main():
     """Run inv."""
     parallel, run_func, _ = parallel_func(run_inverse, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/13-make_inverse.py
+++ b/13-make_inverse.py
@@ -31,7 +31,7 @@ def run_inverse(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/13-make_inverse.py
+++ b/13-make_inverse.py
@@ -27,7 +27,7 @@ def run_inverse(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/13-make_inverse.py
+++ b/13-make_inverse.py
@@ -85,7 +85,7 @@ def main():
     """Run inv."""
     parallel, run_func, _ = parallel_func(run_inverse, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
 
 if __name__ == '__main__':

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -75,11 +75,10 @@ def main():
     parallel, run_func, _ = parallel_func(morph_stc, n_jobs=config.N_JOBS)
     all_morphed_stcs = parallel(run_func(subject, session)
                                 for subject, session in
-                                itertools.product(config.subjects_list,
+                                itertools.product(config.get_subjects(),
                                                   config.get_sessions()))
     all_morphed_stcs = [morphed_stcs for morphed_stcs, subject in
-                        zip(all_morphed_stcs, config.subjects_list)
-                        if subject not in config.exclude_subjects]
+                        zip(all_morphed_stcs, config.get_subjects())]
     mean_morphed_stcs = map(sum, zip(*all_morphed_stcs))
 
     fpath_deriv = op.join(config.bids_root, 'derivatives',

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -40,8 +40,8 @@ def morph_stc(subject, session=None):
                                        space=config.space
                                        )
 
-    mne.utils.set_config('SUBJECTS_DIR', config.subjects_dir)
-    mne.datasets.fetch_fsaverage(subjects_dir=config.subjects_dir)
+    mne.utils.set_config('SUBJECTS_DIR', config.get_subjects_dir())
+    mne.datasets.fetch_fsaverage(subjects_dir=config.get_subjects_dir())
 
     morphed_stcs = []
     for condition in config.conditions:
@@ -58,9 +58,9 @@ def morph_stc(subject, session=None):
                                                 hemi_str]))
 
         stc = mne.read_source_estimate(fname_stc)
-        morph = mne.compute_source_morph(stc, subject_from=subject,
-                                         subject_to='fsaverage',
-                                         subjects_dir=config.subjects_dir)
+        morph = mne.compute_source_morph(
+            stc, subject_from=subject, subject_to='fsaverage',
+            subjects_dir=config.get_subjects_dir())
         stc_fsaverage = morph.apply(stc)
         stc_fsaverage.save(fname_stc_fsaverage)
         morphed_stcs.append(stc_fsaverage)

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -32,7 +32,7 @@ def morph_stc(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
@@ -84,7 +84,7 @@ def main():
     fpath_deriv = op.join(config.bids_root, 'derivatives',
                           config.PIPELINE_NAME)
 
-    bids_basename = make_bids_basename(task=config.task,
+    bids_basename = make_bids_basename(task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -25,7 +25,7 @@ def morph_stc(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     fpath_deriv = op.join(config.bids_root, 'derivatives',
                           config.PIPELINE_NAME, subject_path)

--- a/14-group_average_source.py
+++ b/14-group_average_source.py
@@ -76,7 +76,7 @@ def main():
     all_morphed_stcs = parallel(run_func(subject, session)
                                 for subject, session in
                                 itertools.product(config.subjects_list,
-                                                  config.sessions))
+                                                  config.get_sessions()))
     all_morphed_stcs = [morphed_stcs for morphed_stcs, subject in
                         zip(all_morphed_stcs, config.subjects_list)
                         if subject not in config.exclude_subjects]

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -100,7 +100,7 @@ def main():
     """Make reports."""
     parallel, run_func, _ = parallel_func(run_report, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.get_sessions()))
+             itertools.product(config.get_subjects(), config.get_sessions()))
 
     # Group report
     evoked_fname = op.join(config.bids_root, 'derivatives',

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -26,7 +26,7 @@ def run_report(subject, session=None):
     if session is not None:
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
-    subject_path = op.join(subject_path, config.kind)
+    subject_path = op.join(subject_path, config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -88,7 +88,7 @@ def run_report(subject, session=None):
                                  initial_time=peak_time)
                 fig = brain._figures[0]
                 rep.add_figs_to_section(fig, evoked.condition)
-                
+
                 del peak_time
 
     task_str = 'task-%s' % config.task
@@ -100,7 +100,7 @@ def main():
     """Make reports."""
     parallel, run_func, _ = parallel_func(run_report, n_jobs=config.N_JOBS)
     parallel(run_func(subject, session) for subject, session in
-             itertools.product(config.subjects_list, config.sessions))
+             itertools.product(config.subjects_list, config.get_sessions()))
 
     # Group report
     evoked_fname = op.join(config.bids_root, 'derivatives',

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -30,7 +30,7 @@ def run_report(subject, session=None):
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
-                                       task=config.task,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
@@ -91,8 +91,12 @@ def run_report(subject, session=None):
 
                 del peak_time
 
-    task_str = 'task-%s' % config.task
-    fname_report = op.join(fpath_deriv, 'report_%s.html' % task_str)
+    if config.get_task():
+        task_str = '_task-%s' % config.get_task()
+    else:
+        task_str = ''
+
+    fname_report = op.join(fpath_deriv, 'report%s.html' % task_str)
     rep.save(fname=fname_report, open_browser=False, overwrite=True)
 
 
@@ -113,7 +117,7 @@ def main():
     fpath_deriv = op.join(config.bids_root, 'derivatives',
                           config.PIPELINE_NAME)
 
-    bids_basename = make_bids_basename(task=config.task,
+    bids_basename = make_bids_basename(task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
@@ -148,8 +152,12 @@ def main():
 
             del peak_time
 
-    task_str = 'task-%s' % config.task
-    fname_report = op.join(fpath_deriv, 'report_average_%s.html' % task_str)
+    if config.get_task():
+        task_str = '_task-%s' % config.get_task()
+    else:
+        task_str = ''
+
+    fname_report = op.join(fpath_deriv, 'report_average%s.html' % task_str)
     rep.save(fname=fname_report, open_browser=False, overwrite=True)
 
 

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -44,7 +44,7 @@ def run_report(subject, session=None):
         op.join(fpath_deriv, bids_basename + '-ave.fif')
     fname_trans = \
         op.join(fpath_deriv, 'sub-{}'.format(subject) + '-trans.fif')
-    subjects_dir = config.subjects_dir
+    subjects_dir = config.get_subjects_dir()
     if not op.exists(fname_trans):
         subject = None
         subjects_dir = None
@@ -69,7 +69,7 @@ def run_report(subject, session=None):
     if op.exists(fname_trans):
         fig = mne.viz.plot_alignment(evoked.info, fname_trans,
                                      subject=subject,
-                                     subjects_dir=config.subjects_dir,
+                                     subjects_dir=config.get_subjects_dir(),
                                      meg=True, dig=True, eeg=True)
         rep.add_figs_to_section(fig, 'Coregistration')
 
@@ -111,7 +111,7 @@ def main():
                            config.PIPELINE_NAME,
                            '%s_grand_average-ave.fif' % config.study_name)
     rep = mne.Report(info_fname=evoked_fname, subject='fsaverage',
-                     subjects_dir=config.subjects_dir)
+                     subjects_dir=config.get_subjects_dir())
     evokeds = mne.read_evokeds(evoked_fname)
 
     fpath_deriv = op.join(config.bids_root, 'derivatives',
@@ -144,7 +144,7 @@ def main():
             stc = mne.read_source_estimate(fname_stc_avg, subject='fsaverage')
             _, peak_time = stc.get_peak()
             brain = stc.plot(views=['lat'], hemi='both', subject='fsaverage',
-                             subjects_dir=config.subjects_dir,
+                             subjects_dir=config.get_subjects_dir(),
                              initial_time=peak_time)
 
             fig = brain._figures[0]

--- a/config.py
+++ b/config.py
@@ -854,3 +854,20 @@ def get_kind():
         return 'eeg'
     else:
         return 'meg'
+
+
+def get_reject():
+    reject_ = reject.copy()  # Avoid clash with global variable.
+    kind = get_kind()
+
+    if kind == 'eeg':
+        ch_types_to_remove = ('mag', 'grad')
+    else:
+        ch_types_to_remove = ('eeg',)
+
+    for ch_type in ch_types_to_remove:
+        try:
+            del reject_[ch_type]
+        except KeyError:
+            pass
+    return reject_

--- a/config.py
+++ b/config.py
@@ -811,3 +811,10 @@ def get_subjects():
         s = subjects_list
 
     return list(set(s) - set(exclude_subjects))
+
+
+def get_task():
+    if not task:
+        return None
+    else:
+        return task

--- a/config.py
+++ b/config.py
@@ -815,6 +815,6 @@ def get_subjects():
 
 def get_task():
     if not task:
-        return None
+        return get_entity_vals(bids_root, entity_key='task')[0]
     else:
         return task

--- a/config.py
+++ b/config.py
@@ -792,7 +792,7 @@ if use_ssp and use_ica:
 # ----------------
 
 def get_sessions():
-    sessions_ = copy.deepcopy(sessions)
+    sessions_ = copy.deepcopy(sessions)  # Avoid clash with global variable.
 
     if sessions_ == 'all':
         sessions_ = get_entity_vals(bids_root, entity_key='ses')
@@ -804,7 +804,7 @@ def get_sessions():
 
 
 def get_runs():
-    runs_ = copy.deepcopy(runs)
+    runs_ = copy.deepcopy(runs)  # Avoid clash with global variable.
 
     if runs_ == 'all':
         runs_ = get_entity_vals(bids_root, entity_key='run')

--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ bids_root = None
 #   derivativesfor all subjects. Specifically, the ``subjects_dir`` is the
 #   $SUBJECTS_DIR used by the Freesurfer software.
 
-subjects_dir = os.path.join(bids_root, 'derivatives', 'freesurfer', 'subjects')
+subjects_dir = None
 
 # ``daysback``  : int
 #   If not None apply a time shift to dates to adjust for limitateions
@@ -96,11 +96,7 @@ kind = 'meg'
 #   needs to be set up as a list with a single element, as in the 'example'
 #   subjects_list = ['SB01']
 
-# subjects_list = ['05', '06', '07']
-
-subjects_list = get_entity_vals(bids_root, entity_key='sub')
-
-# subjects_list = ['05']
+subjects_list = 'all'
 
 # ``exclude_subjects`` : list of str
 #   Now you can specify subjects to exclude from the group study:
@@ -112,8 +108,6 @@ subjects_list = get_entity_vals(bids_root, entity_key='sub')
 # did not understand the instructions, etc, ...)
 
 exclude_subjects = ['emptyroom']
-subjects_list = list(set(subjects_list) - set(exclude_subjects))
-
 
 # ``ch_types``  : list of st
 #    The list of channel types to consider.
@@ -274,6 +268,9 @@ mf_head_origin = 'auto'
 # cal_files_path = os.path.join(study_path, 'SSS')
 # mf_ctc_fname = os.path.join(cal_files_path, 'ct_sparse_mgh.fif')
 # mf_cal_fname = os.path.join(cal_files_path, 'sss_cal_mgh.dat')
+
+mf_ctc_fname = ''
+mf_cal_fname = ''
 
 # Despite all possible care to avoid movements in the MEG, the participant
 # will likely slowly drift down from the Dewar or slightly shift the head
@@ -805,3 +802,12 @@ def get_runs():
         return get_entity_vals(bids_root, entity_key='run')
     else:
         return runs
+
+
+def get_subjects():
+    if subjects_list == 'all':
+        s = get_entity_vals(bids_root, entity_key='sub')
+    else:
+        s = subjects_list
+
+    return list(set(s) - set(exclude_subjects))

--- a/config.py
+++ b/config.py
@@ -42,10 +42,11 @@ study_name = ''
 
 bids_root = None
 
-# ``subjects_dir`` : str
+# ``subjects_dir`` : str or None
 #   Path to the directory that contains the MRI data files and their
 #   derivativesfor all subjects. Specifically, the ``subjects_dir`` is the
-#   $SUBJECTS_DIR used by the Freesurfer software.
+#   $SUBJECTS_DIR used by the Freesurfer software. If ``None``, will use
+#   ``'bids_root/derivatives/freesurfer/subjects'``.
 
 subjects_dir = None
 
@@ -662,12 +663,6 @@ smooth = 10
 
 fsaverage_vertices = [np.arange(10242), np.arange(10242)]
 
-# if not os.path.isdir(study_path):
-#     os.mkdir(study_path)
-
-# if not os.path.isdir(subjects_dir):
-#    os.mkdir(subjects_dir)
-
 ###############################################################################
 # ADVANCED
 # --------
@@ -871,3 +866,10 @@ def get_reject():
         except KeyError:
             pass
     return reject_
+
+
+def get_subjects_dir():
+    if not subjects_dir:
+        return os.path.join(bids_root, 'derivatives', 'freesurfer', 'subjects')
+    else:
+        return subjects_dir

--- a/config.py
+++ b/config.py
@@ -795,7 +795,7 @@ if 'eeg' in ch_types:
     if not use_ica:
         msg = ('You did not request ICA artifact correction for your data. '
                'To turn it on, set use_ica=True.')
-        mne.utils.warn(msg)
+        mne.utils.logger.info(msg)
 
 
 ###############################################################################

--- a/config.py
+++ b/config.py
@@ -789,7 +789,7 @@ elif any([ch_type not in ('meg', 'mag', 'grad') for ch_type in ch_types]):
 if 'eeg' in ch_types:
     if use_ssp:
         msg = ('You requested SSP for EEG data via use_ssp=True. However, '
-               'this does not work. Please ICA instead by setting '
+               'this is not presently supported. Please use ICA instead by setting '
                'use_ssp=False and use_ica=True.')
         raise ValueError(msg)
     if not use_ica:

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ of your BIDS dataset to be analyzed.
 import importlib
 import os
 from collections import defaultdict
+import copy
 
 import numpy as np
 from mne_bids.utils import get_entity_vals
@@ -58,7 +59,7 @@ daysback = None
 #   If running the scripts from a notebook or spyder
 #   run %matplotlib qt in the command line to get the plots in extra windows
 
-plot = True
+plot = False
 
 # ``crop`` : tuple or None
 # If tuple, (tmin, tmax) to crop the raw data
@@ -791,15 +792,27 @@ if use_ssp and use_ica:
 # ----------------
 
 def get_sessions():
+    global sessions
+    sessions = copy.deepcopy(sessions)
+
     if sessions == 'all':
-        return get_entity_vals(bids_root, entity_key='ses')
+        sessions = get_entity_vals(bids_root, entity_key='ses')
+
+    if not sessions:
+        return [None]
     else:
         return sessions
 
 
 def get_runs():
+    global runs
+    runs = copy.deepcopy(runs)
+
     if runs == 'all':
-        return get_entity_vals(bids_root, entity_key='run')
+        runs = get_entity_vals(bids_root, entity_key='run')
+
+    if not runs:
+        return [None]
     else:
         return runs
 

--- a/config.py
+++ b/config.py
@@ -792,29 +792,27 @@ if use_ssp and use_ica:
 # ----------------
 
 def get_sessions():
-    global sessions
-    sessions = copy.deepcopy(sessions)
+    sessions_ = copy.deepcopy(sessions)
 
-    if sessions == 'all':
-        sessions = get_entity_vals(bids_root, entity_key='ses')
+    if sessions_ == 'all':
+        sessions_ = get_entity_vals(bids_root, entity_key='ses')
 
-    if not sessions:
+    if not sessions_:
         return [None]
     else:
-        return sessions
+        return sessions_
 
 
 def get_runs():
-    global runs
-    runs = copy.deepcopy(runs)
+    runs_ = copy.deepcopy(runs)
 
-    if runs == 'all':
-        runs = get_entity_vals(bids_root, entity_key='run')
+    if runs_ == 'all':
+        runs_ = get_entity_vals(bids_root, entity_key='run')
 
-    if not runs:
+    if not runs_:
         return [None]
     else:
-        return runs
+        return runs_
 
 
 def get_subjects():

--- a/tests/configs/config_ds000117.py
+++ b/tests/configs/config_ds000117.py
@@ -14,7 +14,6 @@ import os.path as op
 
 study_name = 'ds000117'
 task = 'facerecognition'
-kind = 'meg'
 ch_types = ['meg']
 runs = ['01']
 sessions = ['meg']

--- a/tests/configs/config_ds000246.py
+++ b/tests/configs/config_ds000246.py
@@ -1,6 +1,7 @@
 study_name = 'ds000246'
 runs = ['01']
 subjects_list = ['0001']
+ch_types = ['meg']
 reject = {'mag': 4e-12}
 conditions = ['standard', 'deviant', 'button']
 decoding_conditions = [('standard', 'deviant')]

--- a/tests/configs/config_ds000248.py
+++ b/tests/configs/config_ds000248.py
@@ -2,6 +2,7 @@ study_name = 'ds000248'
 subjects_list = ['01']
 conditions = ['Left', 'Right']
 
+ch_types = ['meg']
 mf_ctc_fname = None
 mf_cal_fname = None
 find_flat_channels_meg = True

--- a/tests/configs/config_ds001810.py
+++ b/tests/configs/config_ds001810.py
@@ -15,6 +15,7 @@ export BIDS_ROOT=~/mne_data/ds001810
 study_name = 'ds001810'
 task = 'attentionalblink'
 plot = False
+ch_types = ['eeg']
 reject = {'eeg': 150e-6}
 conditions = ['61510', '61511']
 decoding_conditions = [('61510', '61511')]

--- a/tests/configs/config_ds001971.py
+++ b/tests/configs/config_ds001971.py
@@ -14,7 +14,6 @@ export BIDS_ROOT=~/mne_data/ds001971
 
 study_name = 'ds001971'
 task = 'AudioCueWalkingStudy'
-kind = 'eeg'
 plot = False
 ch_types = ['eeg']
 reject = {'eeg': 150e-6}

--- a/tests/configs/config_ds001971.py
+++ b/tests/configs/config_ds001971.py
@@ -16,6 +16,7 @@ study_name = 'ds001971'
 task = 'AudioCueWalkingStudy'
 kind = 'eeg'
 plot = False
+ch_types = ['eeg']
 reject = {'eeg': 150e-6}
 conditions = ['left', 'right']
 decoding_conditions = [('left', 'right')]

--- a/tests/configs/config_eeg_matchingpennies.py
+++ b/tests/configs/config_eeg_matchingpennies.py
@@ -11,7 +11,7 @@ Download the eeg_matchingpennies dataset from OSF: https://osf.io/cj2dr/
 study_name = 'eeg_matchingpennies'
 subjects_list = ['05']
 task = 'matchingpennies'
-kind = 'eeg'
+ch_types = ['eeg']
 plot = False
 reject = {'eeg': 150e-6}
 conditions = ['left', 'right']

--- a/tests/configs/config_somato.py
+++ b/tests/configs/config_somato.py
@@ -1,2 +1,3 @@
 study_name = 'MNE-somato-data'
 conditions = ['somato_event1']
+ch_types = ['meg']


### PR DESCRIPTION
We need to read the `bids_root` from the custom configuration early (and not at the very end of `config.py`, as is currently the case in `master`).

------

It's becoming more and more clear to me that `config.py`'s complexity is slowly getting out of hand and, like @jasmainak said, it's drifting away from what an ordinary user should have to deal with. I would suggest to start treating it more like an ordinary Python module than just a collection of configuration settings (because in fact we're already past this point anyway), and move the bits that we want to be "user-facing" to an example of a custom configuration file. This PR and #84 make it easy to use different custom configurations; and I'm considering adding a small script `run_pipeline.py` to replace the `Makefile` and allow the user to specify which configuration to use without having to set an `MNE_BIDS_CONFIG_PATH` einvironment variable.

WDYT?