### PR TITLE
MRG: Speed up dataset retrieval via datalad

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,41 +90,41 @@ jobs:
                mkdir ~/reports
 
         # Run tests
-        - run:
-            name: test ds000246
-            command: |
-               export DS=ds000246
-               python tests/run_tests.py ${DS}
-               mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        # - run:
+        #     name: test ds000246
+        #     command: |
+        #        export DS=ds000246
+        #        python tests/run_tests.py ${DS}
+        #        mkdir ~/reports/${DS}
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        - run:
-            name: test ds000248
-            command: |
-               export DS=ds000248
-               python tests/run_tests.py ${DS}
-               mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        # - run:
+        #     name: test ds000248
+        #     command: |
+        #        export DS=ds000248
+        #        python tests/run_tests.py ${DS}
+        #        mkdir ~/reports/${DS}
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        - run:
-            name: test ds001810
-            command: |
-               export DS=ds001810
-               python tests/run_tests.py ${DS}
-               mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        # - run:
+        #     name: test ds001810
+        #     command: |
+        #        export DS=ds001810
+        #        python tests/run_tests.py ${DS}
+        #        mkdir ~/reports/${DS}
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report_*.html ~/reports/${DS}/
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        - run:
-            name: test eeg_matchingpennies
-            command: |
-               export DS=eeg_matchingpennies
-               python tests/run_tests.py ${DS}
-               mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        # - run:
+        #     name: test eeg_matchingpennies
+        #     command: |
+        #        export DS=eeg_matchingpennies
+        #        python tests/run_tests.py ${DS}
+        #        mkdir ~/reports/${DS}
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
         - run:
             name: test somato

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,41 +90,41 @@ jobs:
                mkdir ~/reports
 
         # Run tests
-        # - run:
-        #     name: test ds000246
-        #     command: |
-        #        export DS=ds000246
-        #        python tests/run_tests.py ${DS}
-        #        mkdir ~/reports/${DS}
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        - run:
+            name: test ds000246
+            command: |
+               export DS=ds000246
+               python tests/run_tests.py ${DS}
+               mkdir ~/reports/${DS}
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        # - run:
-        #     name: test ds000248
-        #     command: |
-        #        export DS=ds000248
-        #        python tests/run_tests.py ${DS}
-        #        mkdir ~/reports/${DS}
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        - run:
+            name: test ds000248
+            command: |
+               export DS=ds000248
+               python tests/run_tests.py ${DS}
+               mkdir ~/reports/${DS}
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        # - run:
-        #     name: test ds001810
-        #     command: |
-        #        export DS=ds001810
-        #        python tests/run_tests.py ${DS}
-        #        mkdir ~/reports/${DS}
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report_*.html ~/reports/${DS}/
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        - run:
+            name: test ds001810
+            command: |
+               export DS=ds001810
+               python tests/run_tests.py ${DS}
+               mkdir ~/reports/${DS}
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
-        # - run:
-        #     name: test eeg_matchingpennies
-        #     command: |
-        #        export DS=eeg_matchingpennies
-        #        python tests/run_tests.py ${DS}
-        #        mkdir ~/reports/${DS}
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-        #        cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+        - run:
+            name: test eeg_matchingpennies
+            command: |
+               export DS=eeg_matchingpennies
+               python tests/run_tests.py ${DS}
+               mkdir ~/reports/${DS}
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
 
         - run:
             name: test somato

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -79,13 +79,10 @@ def main(dataset):
         print('datalad installing "{}"'.format(dsname))
         dataset = dl.install(path=dspath, source=url)
 
-        # XXX: git-annex bug: https://github.com/datalad/datalad/issues/3583
-        # if datalad fails, use "get" twice, or set `n_jobs=1`
-        n_jobs = 1
         # get the first subject
         for to_get in get_dict[dsname]:
             print('datalad get data "{}" for "{}"'.format(to_get, dsname))
-            dataset.get(to_get, jobs=n_jobs)
+            dataset.get(to_get, jobs='auto')
 
 
 if __name__ == '__main__':

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -79,10 +79,13 @@ def main(dataset):
         print('datalad installing "{}"'.format(dsname))
         dataset = dl.install(path=dspath, source=url)
 
+        # XXX: git-annex bug: https://github.com/datalad/datalad/issues/3583
+        # if datalad fails, use "get" twice, or set `n_jobs=1`
+        n_jobs = 1
         # get the first subject
         for to_get in get_dict[dsname]:
             print('datalad get data "{}" for "{}"'.format(to_get, dsname))
-            dataset.get(to_get, jobs=8)
+            dataset.get(to_get, jobs=n_jobs)
 
 
 if __name__ == '__main__':

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -82,7 +82,7 @@ def main(dataset):
         # get the first subject
         for to_get in get_dict[dsname]:
             print('datalad get data "{}" for "{}"'.format(to_get, dsname))
-            dataset.get(to_get, jobs='auto')
+            dataset.get(to_get, jobs=8)
 
 
 if __name__ == '__main__':

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -82,7 +82,7 @@ def main(dataset):
         # XXX: git-annex bug: https://github.com/datalad/datalad/issues/3583
         # if datalad fails, use "get" twice, or set `n_jobs=1`
         if dsname == 'somato':
-            n_jobs = 32
+            n_jobs = 16
         else:
             n_jobs = 1
 

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -82,7 +82,7 @@ def main(dataset):
         # XXX: git-annex bug: https://github.com/datalad/datalad/issues/3583
         # if datalad fails, use "get" twice, or set `n_jobs=1`
         if dsname == 'somato':
-            n_jobs = 8
+            n_jobs = 32
         else:
             n_jobs = 1
 

--- a/tests/download_test_data.py
+++ b/tests/download_test_data.py
@@ -81,7 +81,11 @@ def main(dataset):
 
         # XXX: git-annex bug: https://github.com/datalad/datalad/issues/3583
         # if datalad fails, use "get" twice, or set `n_jobs=1`
-        n_jobs = 1
+        if dsname == 'somato':
+            n_jobs = 8
+        else:
+            n_jobs = 1
+
         # get the first subject
         for to_get in get_dict[dsname]:
             print('datalad get data "{}" for "{}"'.format(to_get, dsname))


### PR DESCRIPTION
Since https://github.com/OpenNeuroOrg/datalad-service/issues/96 has been resolved, we can now use more than one job for retrieving the datasets via git-annex. This can considerably speed up dataset retrieval.

Closes GH-95.

@agramfort Let's see what CI thinks about this :)