### PR TITLE
Allow continuation after an error (or, optionally, abort the pipeline)

### DIFF
--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -45,12 +45,12 @@ from mne_bids.config import BIDS_VERSION
 from mne_bids.utils import _write_json
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
-# XXX currently only tested with use_maxwell_filter = False
+@failsafe_run(on_error=on_error)
 def run_maxwell_filter(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -25,11 +25,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_filter(subject, run=None, session=None):
     """Filter data from a single subject."""
     # Construct the search path for the data file. `sub` is mandatory

--- a/03-make_epochs.py
+++ b/03-make_epochs.py
@@ -19,12 +19,13 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
 ###############################################################################
+@failsafe_run(on_error=on_error)
 def run_epochs(subject, session=None):
     """Extract epochs for one subject."""
 

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -21,11 +21,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_ica(subject, session=None):
     """Run ICA."""
 

--- a/04b-run_ssp.py
+++ b/04b-run_ssp.py
@@ -16,11 +16,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_ssp(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/05a-apply_ica.py
+++ b/05a-apply_ica.py
@@ -27,11 +27,12 @@ from mne_bids import make_bids_basename
 
 import numpy as np
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def apply_ica(subject, run, session):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/05b-apply_ssp.py
+++ b/05b-apply_ssp.py
@@ -17,11 +17,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def apply_ssp(subject, session=None):
     # load epochs to reject ICA components
     # compute SSP on first run of raw

--- a/06-make_evoked.py
+++ b/06-make_evoked.py
@@ -16,11 +16,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_evoked(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/08-sliding_estimator.py
+++ b/08-sliding_estimator.py
@@ -30,7 +30,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
@@ -38,6 +38,7 @@ logger = logging.getLogger('mne-study-template')
 ###############################################################################
 # Then we write a function to do time decoding on one subject
 
+@failsafe_run(on_error=on_error)
 def run_time_decoding(subject, condition1, condition2, session=None):
     msg = f'Contrasting conditions: {condition1} – {condition2}'
     logger.info(gen_log_message(message=msg, step=8, subject=subject,

--- a/08-sliding_estimator.py
+++ b/08-sliding_estimator.py
@@ -112,7 +112,7 @@ def main():
             for conditions in config.decoding_conditions:
                 run_time_decoding(subject, *conditions, session=session)
 
-    msg = 'Running Step 8: Sliding estimator'
+    msg = 'Completed Step 8: Sliding estimator'
     logger.info(gen_log_message(step=8, message=msg))
 
 

--- a/09-time_frequency.py
+++ b/09-time_frequency.py
@@ -21,7 +21,7 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
@@ -30,6 +30,7 @@ freqs = np.arange(10, 40)
 n_cycles = freqs / 3.
 
 
+@failsafe_run(on_error=on_error)
 def run_time_frequency(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/10-make_forward.py
+++ b/10-make_forward.py
@@ -18,11 +18,12 @@ from mne_bids import make_bids_basename, get_head_mri_trans
 from mne_bids.read import reader as mne_bids_readers
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_forward(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/10-make_forward.py
+++ b/10-make_forward.py
@@ -118,7 +118,7 @@ def main():
     parallel(run_func(subject, session) for subject, session in
              itertools.product(config.get_subjects(), config.get_sessions()))
 
-    msg = 'Running Step 10: Create forward solution'
+    msg = 'Completed Step 10: Create forward solution'
     logger.info(gen_log_message(step=10, message=msg))
 
 

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -83,7 +83,7 @@ def main():
     parallel(run_func(subject, session) for subject, session in
              itertools.product(config.get_subjects(), config.get_sessions()))
 
-    msg = 'Running Step 11: Estimate noise covariance'
+    msg = 'Completed Step 11: Estimate noise covariance'
     logger.info(gen_log_message(step=11, message=msg))
 
 

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -17,11 +17,12 @@ from mne_bids import make_bids_basename
 from sklearn.model_selection import KFold
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_covariance(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/12-make_inverse.py
+++ b/12-make_inverse.py
@@ -17,11 +17,12 @@ from mne.minimum_norm import (make_inverse_operator, apply_inverse,
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def run_inverse(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -16,11 +16,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def morph_stc(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -113,7 +113,7 @@ def main():
                                                        hemi_str]))
         this_stc.save(fname_stc_avg)
 
-    msg = 'Running Step 13: Grand-average source estimates'
+    msg = 'Completed Step 13: Grand-average source estimates'
     logger.info(gen_log_message(step=13, message=msg))
 
 

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -21,7 +21,6 @@ from config import gen_log_message, on_error, failsafe_run
 logger = logging.getLogger('mne-study-template')
 
 
-@failsafe_run(on_error=on_error)
 def morph_stc(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))
@@ -74,6 +73,7 @@ def morph_stc(subject, session=None):
     return morphed_stcs
 
 
+@failsafe_run(on_error=on_error)
 def main():
     """Run grp ave."""
     msg = 'Running Step 13: Grand-average source estimates'

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -152,7 +152,7 @@ def run_report(subject, session=None):
                     rep.add_figs_to_section(
                         figs=[brain_lh, brain_rh],
                         captions=[f'{evoked.comment} - left hemisphere',
-                                  f'{evoked.comment]} - right hemisphere',
+                                  f'{evoked.comment} - right hemisphere'],
                         section='Sources')
 
                 del peak_time

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -16,11 +16,12 @@ from mne.parallel import parallel_func
 from mne_bids import make_bids_basename
 
 import config
-from config import gen_log_message
+from config import gen_log_message, on_error, failsafe_run
 
 logger = logging.getLogger('mne-study-template')
 
 
+@failsafe_run(on_error=on_error)
 def plot_events(subject, session, fpath_deriv):
     raws_filt = []
     for run in config.get_runs():
@@ -47,6 +48,7 @@ def plot_events(subject, session, fpath_deriv):
     return fig
 
 
+@failsafe_run(on_error=on_error)
 def run_report(subject, session=None):
     # Construct the search path for the data file. `sub` is mandatory
     subject_path = op.join('sub-{}'.format(subject))

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -21,7 +21,6 @@ from config import gen_log_message, on_error, failsafe_run
 logger = logging.getLogger('mne-study-template')
 
 
-@failsafe_run(on_error=on_error)
 def plot_events(subject, session, fpath_deriv):
     raws_filt = []
     for run in config.get_runs():

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -86,8 +86,9 @@ def run_report(subject, session=None):
     # Visualize events.
     events_fig = plot_events(subject=subject, session=session,
                              fpath_deriv=fpath_deriv)
-    rep.add_figs_to_section([events_fig],
-                            ['Events in filtered continuous data'])
+    rep.add_figs_to_section(figs=events_fig,
+                            comments='Events in filtered continuous data',
+                            section='Events')
 
     # Visualize evoked responses.
     evokeds = mne.read_evokeds(fname_ave)
@@ -100,7 +101,7 @@ def run_report(subject, session=None):
         figs.append(fig)
         captions.append(evoked.comment)
 
-    rep.add_figs_to_section(figs, captions)
+    rep.add_figs_to_section(figs=figs, comments=captions, section='Evoked')
 
     if op.exists(fname_trans):
         # We can only plot the coregistration if we have a valid 3d backend.
@@ -188,9 +189,9 @@ def main():
                                        space=config.space)
 
     for evoked, condition in zip(evokeds, config.conditions):
-        rep.add_figs_to_section(evoked.plot(spatial_colors=True, gfp=True,
-                                            show=False),
-                                'Average %s' % condition)
+        fig = evoked.plot(spatial_colors=True, gfp=True, show=False)
+        rep.add_figs_to_section(figs=fig, comments=f'Average {condition}',
+                                section='Evoked')
 
         method = config.inverse_method
         cond_str = 'cond-%s' % condition.replace(op.sep, '')
@@ -229,7 +230,8 @@ def main():
                                         [evoked.comment, evoked.comment])
 
             fig = brain._figures[0]
-            rep.add_figs_to_section(fig, 'Average %s' % condition)
+            rep.add_figs_to_section(figs=fig, comments=f'Average {condition}',
+                                    section='Sources')
 
             del peak_time
 

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -87,7 +87,7 @@ def run_report(subject, session=None):
     events_fig = plot_events(subject=subject, session=session,
                              fpath_deriv=fpath_deriv)
     rep.add_figs_to_section(figs=events_fig,
-                            comments='Events in filtered continuous data',
+                            captions='Events in filtered continuous data',
                             section='Events')
 
     # Visualize evoked responses.
@@ -101,7 +101,7 @@ def run_report(subject, session=None):
         figs.append(fig)
         captions.append(evoked.comment)
 
-    rep.add_figs_to_section(figs=figs, comments=captions, section='Evoked')
+    rep.add_figs_to_section(figs=figs, captions=captions, section='Evoked')
 
     if op.exists(fname_trans):
         # We can only plot the coregistration if we have a valid 3d backend.
@@ -110,7 +110,8 @@ def run_report(subject, session=None):
                                          subject=subject,
                                          subjects_dir=config.subjects_dir,
                                          meg=True, dig=True, eeg=True)
-            rep.add_figs_to_section(fig, 'Coregistration')
+            rep.add_figs_to_section(figs=fig, captions='Coregistration',
+                                    section='Coregistration')
         else:
             msg = ('Cannot render sensor alignment (coregistration) because '
                    'no usable 3d backend was found.')
@@ -134,8 +135,10 @@ def run_report(subject, session=None):
                 if mne.viz.get_3d_backend() is not None:
                     brain = stc.plot(views=['lat'], hemi='both',
                                      initial_time=peak_time,  backend='mayavi')
-                    rep.add_figs_to_section(brain._figures[0],
-                                            evoked.comment)
+                    fig = brain._figures[0]
+                    rep.add_figs_to_section(figs=fig,
+                                            captions=evoked.condition,
+                                            section='Sources')
                 else:
                     import matplotlib.pyplot as plt
                     fig_lh = plt.figure()
@@ -147,8 +150,11 @@ def run_report(subject, session=None):
                     brain_rh = stc.plot(views='lat', hemi='rh',
                                         initial_time=peak_time,
                                         backend='matplotlib', figure=fig_rh)
-                    rep.add_figs_to_section([brain_lh, brain_rh],
-                                            [evoked.comment, evoked.comment])
+                    rep.add_figs_to_section(
+                        figs=[brain_lh, brain_rh],
+                        captions=[f'{evoked.comment} - left hemisphere',
+                                  f'{evoked.comment]} - right hemisphere',
+                        section='Sources')
 
                 del peak_time
 
@@ -190,7 +196,7 @@ def main():
 
     for evoked, condition in zip(evokeds, config.conditions):
         fig = evoked.plot(spatial_colors=True, gfp=True, show=False)
-        rep.add_figs_to_section(figs=fig, comments=f'Average {condition}',
+        rep.add_figs_to_section(figs=fig, captions=f'Average {condition}',
                                 section='Evoked')
 
         method = config.inverse_method
@@ -230,7 +236,7 @@ def main():
                                         [evoked.comment, evoked.comment])
 
             fig = brain._figures[0]
-            rep.add_figs_to_section(figs=fig, comments=f'Average {condition}',
+            rep.add_figs_to_section(figs=fig, captions=f'Average {condition}',
                                     section='Sources')
 
             del peak_time

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import os.path as op
-import shutil
 import argparse
 import importlib
 


### PR DESCRIPTION
The logging isn't really good at the moment: it will inform you _that_ a critical error occurred, but will not provide info about _where_ exactly (which pipeline step, participant, session etc.) That's because the newly-introduced `@failsafe_run` decorator is used like this:

```python
@failsafe_run(on_error=on_error)
def run_maxwell_filter(subject, session=None):
    ...
```
so it would have to extract the arguments passed to the wrapped function in order to generate a more meaningful log message. To make this easier, I would first want to switch all `run` functions to use keyword-only arguments, and then `failsafe_run` could be defined with defaults for all possible keywords. In case of an error, these can then be passed to `gen_log_message` to generate an informative log message.