### PR TITLE
ENH: Add config.deriv_root

### DIFF
--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -227,7 +227,8 @@ def run_maxwell_filter(subject, session=None):
                 destination=destination)
 
             # Prepare a name to save the data
-            raw_fname_out = op.join(deriv_path, bids_basename + '_sss_raw.fif')
+            raw_fname_out = op.join(config.deriv_root, subject_path,
+                                    bids_basename + '_sss_raw.fif')
             raw_sss.save(raw_fname_out, overwrite=True)
 
             if config.plot:
@@ -240,8 +241,8 @@ def run_maxwell_filter(subject, session=None):
             logger.info(gen_log_message(message=msg, step=1,
                                         subject=subject, session=session))
             # Prepare a name to save the data
-            raw_fname_out = op.join(deriv_path, bids_basename +
-                                    '_nosss_raw.fif')
+            raw_fname_out = op.join(config.deriv_root, subject_path,
+                                    bids_basename + '_nosss_raw.fif')
             raw.save(raw_fname_out, overwrite=True)
 
             if config.plot:

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -108,7 +108,7 @@ def run_maxwell_filter(subject, session=None):
                 'URL': 'n/a',
             }
 
-            fname = op.join(deriv_path, 'dataset_description.json')
+            fname = op.join(config.deriv_root, 'dataset_description.json')
             _write_json(fname, ds_json, overwrite=True)
 
         # read_raw_bids automatically

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -91,10 +91,9 @@ def run_maxwell_filter(subject, session=None):
 
         if run_idx == 0:  # XXX does this work when no runs are specified?
             # Prepare the pipeline directory in /derivatives
-            deriv_root = config.deriv_root
-            fpath_out = op.join(deriv_root, subject_path)
-            if not op.exists(fpath_out):
-                os.makedirs(fpath_out)
+            deriv_path = op.join(config.deriv_root, subject_path)
+            if not op.exists(deriv_path):
+                os.makedirs(deriv_path)
 
             # Write a dataset_description.json for the pipeline
             ds_json = dict()
@@ -109,7 +108,7 @@ def run_maxwell_filter(subject, session=None):
                 'URL': 'n/a',
             }
 
-            fname = op.join(deriv_root, 'dataset_description.json')
+            fname = op.join(deriv_path, 'dataset_description.json')
             _write_json(fname, ds_json, overwrite=True)
 
         # read_raw_bids automatically
@@ -229,7 +228,7 @@ def run_maxwell_filter(subject, session=None):
                 destination=destination)
 
             # Prepare a name to save the data
-            raw_fname_out = op.join(fpath_out, bids_basename + '_sss_raw.fif')
+            raw_fname_out = op.join(deriv_path, bids_basename + '_sss_raw.fif')
             raw_sss.save(raw_fname_out, overwrite=True)
 
             if config.plot:
@@ -242,7 +241,7 @@ def run_maxwell_filter(subject, session=None):
             logger.info(gen_log_message(message=msg, step=1,
                                         subject=subject, session=session))
             # Prepare a name to save the data
-            raw_fname_out = op.join(fpath_out, bids_basename +
+            raw_fname_out = op.join(deriv_path, bids_basename +
                                     '_nosss_raw.fif')
             raw.save(raw_fname_out, overwrite=True)
 

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -91,8 +91,8 @@ def run_maxwell_filter(subject, session=None):
 
         if run_idx == 0:  # XXX does this work when no runs are specified?
             # Prepare the pipeline directory in /derivatives
-            deriv_path = config.deriv_root
-            fpath_out = op.join(deriv_path, subject_path)
+            deriv_root = config.deriv_root
+            fpath_out = op.join(deriv_root, subject_path)
             if not op.exists(fpath_out):
                 os.makedirs(fpath_out)
 
@@ -109,7 +109,7 @@ def run_maxwell_filter(subject, session=None):
                 'URL': 'n/a',
             }
 
-            fname = op.join(deriv_path, 'dataset_description.json')
+            fname = op.join(deriv_root, 'dataset_description.json')
             _write_json(fname, ds_json, overwrite=True)
 
         # read_raw_bids automatically

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -91,9 +91,8 @@ def run_maxwell_filter(subject, session=None):
 
         if run_idx == 0:  # XXX does this work when no runs are specified?
             # Prepare the pipeline directory in /derivatives
-            deriv_path = op.join(config.deriv_root, subject_path)
-            if not op.exists(deriv_path):
-                os.makedirs(deriv_path)
+            if not op.exists(config.deriv_root):
+                os.makedirs(config.deriv_root)
 
             # Write a dataset_description.json for the pipeline
             ds_json = dict()

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -91,8 +91,7 @@ def run_maxwell_filter(subject, session=None):
 
         if run_idx == 0:  # XXX does this work when no runs are specified?
             # Prepare the pipeline directory in /derivatives
-            deriv_path = op.join(config.bids_root, 'derivatives',
-                                 config.PIPELINE_NAME)
+            deriv_path = config.deriv_root
             fpath_out = op.join(deriv_path, subject_path)
             if not op.exists(fpath_out):
                 os.makedirs(fpath_out)

--- a/02-frequency_filter.py
+++ b/02-frequency_filter.py
@@ -52,14 +52,13 @@ def run_filter(subject, run=None, session=None):
                                        )
 
     # Prepare a name to save the data
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
+    deriv_path = op.join(config.deriv_root, subject_path)
     if config.use_maxwell_filter:
-        raw_fname_in = op.join(fpath_deriv, bids_basename + '_sss_raw.fif')
+        raw_fname_in = op.join(deriv_path, bids_basename + '_sss_raw.fif')
     else:
-        raw_fname_in = op.join(fpath_deriv, bids_basename + '_nosss_raw.fif')
+        raw_fname_in = op.join(deriv_path, bids_basename + '_nosss_raw.fif')
 
-    raw_fname_out = op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+    raw_fname_out = op.join(deriv_path, bids_basename + '_filt_raw.fif')
 
     msg = f'Input: {raw_fname_in}, Output: {raw_fname_out}'
     logger.info(gen_log_message(message=msg, step=2, subject=subject,

--- a/03-make_epochs.py
+++ b/03-make_epochs.py
@@ -49,11 +49,10 @@ def run_epochs(subject, session=None):
                                            space=config.space
                                            )
         # Prepare a name to save the data
-        fpath_deriv = op.join(config.bids_root, 'derivatives',
-                              config.PIPELINE_NAME, subject_path)
+        deriv_path = op.join(config.deriv_root, subject_path)
 
         raw_fname_in = \
-            op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+            op.join(deriv_path, bids_basename + '_filt_raw.fif')
 
         msg = f'Loading filtered raw data from {raw_fname_in}'
         logger.info(gen_log_message(message=msg, step=3, subject=subject,
@@ -114,7 +113,7 @@ def run_epochs(subject, session=None):
                                        )
 
     epochs_fname = \
-        op.join(fpath_deriv, bids_basename + '-epo.fif')
+        op.join(deriv_path, bids_basename + '-epo.fif')
     epochs.save(epochs_fname, overwrite=True)
 
     if config.plot:

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -37,10 +37,7 @@ def run_ica(subject, session=None):
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
     subject_path = op.join(subject_path, config.get_kind())
-
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-
+    deriv_path = op.join(config.deriv_root, subject_path)
     raw_list = list()
     msg = 'Loading filtered raw data'
     logger.info(gen_log_message(message=msg, step=4, subject=subject,
@@ -58,7 +55,7 @@ def run_ica(subject, session=None):
                                            )
 
         raw_fname_in = \
-            op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+            op.join(deriv_path, bids_basename + '_filt_raw.fif')
 
         raw = mne.io.read_raw_fif(raw_fname_in, preload=True)
         raw_list.append(raw)
@@ -135,15 +132,14 @@ def run_ica(subject, session=None):
 
     # Load ICA
     ica_fname = \
-        op.join(fpath_deriv, bids_basename + '_%s-ica.fif' % kind)
+        op.join(deriv_path, bids_basename + '_%s-ica.fif' % kind)
 
     ica.save(ica_fname)
 
     if config.plot:
         # plot ICA components to html report
         report_fname = \
-            op.join(fpath_deriv,
-                    bids_basename + '_%s-ica.html' % kind)
+            op.join(deriv_path, f'bids_basename_{kind}-ica.html')
 
         report = Report(report_fname, verbose=False)
 

--- a/04b-run_ssp.py
+++ b/04b-run_ssp.py
@@ -45,11 +45,8 @@ def run_ssp(subject, session=None):
                                        )
 
     # Prepare a name to save the data
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-
-    raw_fname_in = \
-        op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+    deriv_path = op.join(config.deriv_root, subject_path)
+    raw_fname_in = op.join(deriv_path, bids_basename + '_filt_raw.fif')
 
     # when saving proj, use bids_basename=None
     bids_basename = make_bids_basename(subject=subject,
@@ -62,7 +59,7 @@ def run_ssp(subject, session=None):
                                        space=config.space
                                        )
 
-    proj_fname_out = op.join(fpath_deriv, bids_basename + '_ssp-proj.fif')
+    proj_fname_out = op.join(deriv_path, bids_basename + '_ssp-proj.fif')
 
     msg = f'Input: {raw_fname_in}, Output: {proj_fname_out}'
     logger.info(gen_log_message(message=msg, step=4, subject=subject,

--- a/05a-apply_ica.py
+++ b/05a-apply_ica.py
@@ -52,13 +52,10 @@ def apply_ica(subject, run, session):
                                        space=config.space
                                        )
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_in = \
-        op.join(fpath_deriv, bids_basename + '-epo.fif')
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_in = op.join(deriv_path, bids_basename + '-epo.fif')
 
-    fname_out = \
-        op.join(fpath_deriv, bids_basename + '_cleaned-epo.fif')
+    fname_out = op.join(deriv_path, bids_basename + '_cleaned-epo.fif')
 
     # load epochs to reject ICA components
     epochs = mne.read_epochs(fname_in, preload=True)
@@ -83,11 +80,10 @@ def apply_ica(subject, run, session):
                                        )
 
     if config.use_maxwell_filter:
-        raw_fname_in = \
-            op.join(fpath_deriv, bids_basename + '_sss_raw.fif')
+        raw_fname_in = op.join(deriv_path, bids_basename + '_sss_raw.fif')
     else:
         raw_fname_in = \
-            op.join(fpath_deriv, bids_basename + '_filt_raw.fif')
+            op.join(deriv_path, bids_basename + '_filt_raw.fif')
 
     raw = mne.io.read_raw_fif(raw_fname_in, preload=True)
 
@@ -103,8 +99,7 @@ def apply_ica(subject, run, session):
         picks = all_picks[ch_type]
 
         # Load ICA
-        fname_ica = \
-            op.join(fpath_deriv, bids_basename + '_%s-ica.fif' % ch_type)
+        fname_ica = op.join(deriv_path, f'bids_basename_{ch_type}-ica.fif')
 
         msg = f'Reading ICA: {fname_ica}'
         logger.debug(gen_log_message(message=msg, step=5, subject=subject,
@@ -140,8 +135,8 @@ def apply_ica(subject, run, session):
             del ecg_epochs
 
             report_fname = \
-                op.join(fpath_deriv,
-                        bids_basename + '_%s-reject_ica.html' % ch_type)
+                op.join(deriv_path,
+                        bids_basename + f'_{ch_type}-reject_ica.html')
 
             report = Report(report_fname, verbose=False)
 

--- a/05b-apply_ssp.py
+++ b/05b-apply_ssp.py
@@ -44,13 +44,12 @@ def apply_ssp(subject, session=None):
                                        space=config.space
                                        )
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
+    deriv_path = op.join(config.deriv_root, subject_path)
     fname_in = \
-        op.join(fpath_deriv, bids_basename + '-epo.fif')
+        op.join(deriv_path, bids_basename + '-epo.fif')
 
     fname_out = \
-        op.join(fpath_deriv, bids_basename + '_cleaned-epo.fif')
+        op.join(deriv_path, bids_basename + '_cleaned-epo.fif')
 
     epochs = mne.read_epochs(fname_in, preload=True)
 
@@ -59,7 +58,7 @@ def apply_ssp(subject, session=None):
                                 session=session))
 
     proj_fname_in = \
-        op.join(fpath_deriv, bids_basename + '_ssp-proj.fif')
+        op.join(deriv_path, bids_basename + '_ssp-proj.fif')
 
     msg = f'Reading SSP projections from : {proj_fname_in}'
     logger.info(gen_log_message(message=msg, step=5, subject=subject,

--- a/06-make_evoked.py
+++ b/06-make_evoked.py
@@ -46,13 +46,12 @@ def run_evoked(subject, session=None):
     else:
         extension = '-epo'
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
+    deriv_path = op.join(config.deriv_root, subject_path)
     fname_in = \
-        op.join(fpath_deriv, bids_basename + '%s.fif' % extension)
+        op.join(deriv_path, bids_basename + '%s.fif' % extension)
 
     fname_out = \
-        op.join(fpath_deriv, bids_basename + '-ave.fif')
+        op.join(deriv_path, bids_basename + '-ave.fif')
 
     msg = f'Input: {fname_in}, Output: {fname_out}'
     logger.info(gen_log_message(message=msg, step=5, subject=subject,

--- a/07-group_average_sensors.py
+++ b/07-group_average_sensors.py
@@ -55,12 +55,9 @@ for subject in config.get_subjects():
     else:
         extension = '-epo'
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
+    deriv_path = op.join(config.deriv_root, subject_path)
 
-    fname_in = \
-        op.join(fpath_deriv, bids_basename + '-ave.fif')
-
+    fname_in = op.join(deriv_path, bids_basename + '-ave.fif')
     msg = f'Input: {fname_in}'
     logger.info(gen_log_message(message=msg, step=7, subject=subject,
                                 session=session))

--- a/08-sliding_estimator.py
+++ b/08-sliding_estimator.py
@@ -62,10 +62,8 @@ def run_time_decoding(subject, condition1, condition2, session=None):
                                        space=config.space
                                        )
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_in = \
-        op.join(fpath_deriv, bids_basename + '-epo.fif')
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_in = op.join(deriv_path, bids_basename + '-epo.fif')
 
     epochs = mne.read_epochs(fname_in)
 

--- a/09-time_frequency.py
+++ b/09-time_frequency.py
@@ -55,10 +55,8 @@ def run_time_frequency(subject, session=None):
     else:
         extension = '-epo'
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_in = \
-        op.join(fpath_deriv, bids_basename + '%s.fif' % extension)
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_in = op.join(deriv_path, bids_basename + '%s.fif' % extension)
 
     msg = f'Input: {fname_in}'
     logger.info(gen_log_message(message=msg, step=9, subject=subject,
@@ -72,11 +70,11 @@ def run_time_frequency(subject, session=None):
             this_epochs, freqs=freqs, return_itc=True, n_cycles=n_cycles)
 
         power_fname_out = \
-            op.join(fpath_deriv, bids_basename + '_power_%s-tfr.h5'
+            op.join(deriv_path, bids_basename + '_power_%s-tfr.h5'
                     % (condition.replace(op.sep, '')))
 
         itc_fname_out = \
-            op.join(fpath_deriv, bids_basename + '_itc_%s-tfr.h5'
+            op.join(deriv_path, bids_basename + '_itc_%s-tfr.h5'
                     % (condition.replace(op.sep, '')))
 
         power.save(power_fname_out, overwrite=True)

--- a/10-make_forward.py
+++ b/10-make_forward.py
@@ -43,16 +43,12 @@ def run_forward(subject, session=None):
                                        space=config.space
                                        )
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_evoked = \
-        op.join(fpath_deriv, bids_basename + '-ave.fif')
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_evoked = op.join(deriv_path, bids_basename + '-ave.fif')
 
-    fname_trans = \
-        op.join(fpath_deriv, 'sub-{}'.format(subject) + '-trans.fif')
+    fname_trans = op.join(deriv_path, 'sub-{}'.format(subject) + '-trans.fif')
 
-    fname_fwd = \
-        op.join(fpath_deriv, bids_basename + '-fwd.fif')
+    fname_fwd = op.join(deriv_path, bids_basename + '-fwd.fif')
 
     msg = f'Input: {fname_evoked}, Output: {fname_fwd}'
     logger.info(gen_log_message(message=msg, step=10, subject=subject,

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -47,13 +47,10 @@ def run_covariance(subject, session=None):
     else:
         extension = '-epo'
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_epo = \
-        op.join(fpath_deriv, bids_basename + '%s.fif' % extension)
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_epo = op.join(deriv_path, bids_basename + '%s.fif' % extension)
 
-    fname_cov = \
-        op.join(fpath_deriv, bids_basename + '-cov.fif')
+    fname_cov = op.join(deriv_path, bids_basename + '-cov.fif')
 
     msg = f'Input: {fname_epo}, Output: {fname_cov}'
     logger.info(gen_log_message(message=msg, step=11, subject=subject,

--- a/12-make_inverse.py
+++ b/12-make_inverse.py
@@ -42,19 +42,14 @@ def run_inverse(subject, session=None):
                                        space=config.space
                                        )
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
-    fname_ave = \
-        op.join(fpath_deriv, bids_basename + '-ave.fif')
+    deriv_path = op.join(config.deriv_root, subject_path)
+    fname_ave = op.join(deriv_path, bids_basename + '-ave.fif')
 
-    fname_fwd = \
-        op.join(fpath_deriv, bids_basename + '-fwd.fif')
+    fname_fwd = op.join(deriv_path, bids_basename + '-fwd.fif')
 
-    fname_cov = \
-        op.join(fpath_deriv, bids_basename + '-cov.fif')
+    fname_cov = op.join(deriv_path, bids_basename + '-cov.fif')
 
-    fname_inv = \
-        op.join(fpath_deriv, bids_basename + '-inv.fif')
+    fname_inv = op.join(deriv_path, bids_basename + '-inv.fif')
 
     evokeds = mne.read_evokeds(fname_ave)
     cov = mne.read_cov(fname_cov)
@@ -75,8 +70,8 @@ def run_inverse(subject, session=None):
         cond_str = 'cond-%s' % condition.replace(op.sep, '')
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
-        fname_stc = op.join(fpath_deriv, '_'.join([bids_basename, cond_str,
-                                                   inverse_str, hemi_str]))
+        fname_stc = op.join(deriv_path, '_'.join([bids_basename, cond_str,
+                                                  inverse_str, hemi_str]))
 
         stc = apply_inverse(evoked=evoked,
                             inverse_operator=inverse_operator,

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -29,9 +29,7 @@ def morph_stc(subject, session=None):
         subject_path = op.join(subject_path, 'ses-{}'.format(session))
 
     subject_path = op.join(subject_path, config.get_kind())
-
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME, subject_path)
+    deriv_path = op.join(config.deriv_root, subject_path)
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -53,9 +51,9 @@ def morph_stc(subject, session=None):
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         morph_str = 'morph-fsaverage'
-        fname_stc = op.join(fpath_deriv, '_'.join([bids_basename, cond_str,
-                                                   inverse_str, hemi_str]))
-        fname_stc_fsaverage = op.join(fpath_deriv,
+        fname_stc = op.join(deriv_path, '_'.join([bids_basename, cond_str,
+                                                  inverse_str, hemi_str]))
+        fname_stc_fsaverage = op.join(deriv_path,
                                       '_'.join([bids_basename, cond_str,
                                                 inverse_str, morph_str,
                                                 hemi_str]))
@@ -88,8 +86,7 @@ def main():
                         zip(all_morphed_stcs, config.get_subjects())]
     mean_morphed_stcs = map(sum, zip(*all_morphed_stcs))
 
-    fpath_deriv = op.join(config.bids_root, 'derivatives',
-                          config.PIPELINE_NAME)
+    deriv_path = config.deriv_root
 
     bids_basename = make_bids_basename(task=config.get_task(),
                                        acquisition=config.acq,
@@ -107,10 +104,10 @@ def main():
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         morph_str = 'morph-fsaverage'
 
-        fname_stc_avg = op.join(fpath_deriv, '_'.join(['average',
-                                                       bids_basename, cond_str,
-                                                       inverse_str, morph_str,
-                                                       hemi_str]))
+        fname_stc_avg = op.join(deriv_path, '_'.join(['average',
+                                                      bids_basename, cond_str,
+                                                      inverse_str, morph_str,
+                                                      hemi_str]))
         this_stc.save(fname_stc_avg)
 
     msg = 'Completed Step 13: Grand-average source estimates'

--- a/config.py
+++ b/config.py
@@ -523,8 +523,8 @@ ica_algorithm = 'picard'
 
 # ``ica_max_iterations`` : int
 #   Maximum number of iterations to decompose the data into independent
-#   components. A low number means to finish earlier, but the consequence is that the
-#   algorithm may not have finished converging. To ensure
+#   components. A low number means to finish earlier, but the consequence is
+#   that the algorithm may not have finished converging. To ensure
 #   convergence, pick a high number here (e.g. 3000); yet the algorithm will
 #   terminate as soon as it determines that is has successfully converged, and
 #   not necessarily exhaust the maximum number of iterations. Note that the
@@ -791,6 +791,12 @@ if not bids_root:
            'define an environment variable `BIDS_ROOT` pointing to the '
            'root folder of your BIDS dataset')
     raise ValueError(msg)
+
+
+###############################################################################
+# Derivates root
+# --------------
+deriv_root = os.path.join(bids_root, 'derivatives', PIPELINE_NAME)
 
 
 ###############################################################################


### PR DESCRIPTION
Allows specification of the root folder of the derivatives. Currently not meant to be user-settable.
Removes redundant code across the entire pipeline.