### PR TITLE
[MRG] ENH: Keep a log of auto-detected bad channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             name: Install dependencies in conda base environment
             command: |
               conda update -n base -c defaults conda
-              pip install numpy scipy matplotlib nibabel coloredlogs python-picard
+              pip install numpy scipy pandas matplotlib nibabel coloredlogs python-picard
               pip install -U scikit-learn
               pip install --upgrade https://api.github.com/repos/mne-tools/mne-python/zipball/master
               git clone https://github.com/mne-tools/mne-bids.git --depth 1

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -172,7 +172,7 @@ def find_bad_channels(raw, subject, session, task, run):
                        len(preexisting_bads))
 
     tsv_data = pd.DataFrame(dict(name=bads_for_tsv, reason=reasons))
-    tsv_data = tsv_data.sort_values(by='Channel')
+    tsv_data = tsv_data.sort_values(by='name')
     tsv_data.to_csv(bads_tsv_fname, sep='\t', index=False)
 
 

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -151,7 +151,7 @@ def find_bad_channels(raw, subject, session, task, run):
                                        recording=config.rec,
                                        space=config.space)
 
-    bads_tsv_fname = op.join(deriv_path, f'{bids_basename}_bad_chans.tsv')
+    bads_tsv_fname = op.join(deriv_path, f'{bids_basename}_bad_channels.tsv')
     bads_for_tsv = []
     reasons = []
 

--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -171,7 +171,7 @@ def find_bad_channels(raw, subject, session, task, run):
         reasons.extend(['pre-existing (before mne-study-template was run)'] *
                        len(preexisting_bads))
 
-    tsv_data = pd.DataFrame(dict(Channel=bads_for_tsv, Reason=reasons))
+    tsv_data = pd.DataFrame(dict(name=bads_for_tsv, reason=reasons))
     tsv_data = tsv_data.sort_values(by='Channel')
     tsv_data.to_csv(bads_tsv_fname, sep='\t', index=False)
 


### PR DESCRIPTION
- It's good to have
- I need it for empty-room handling

To give you an example: with the `ds000248` dataset, it produces a file:
`sub-01/meg/sub-01_task-audiovisual_run-01_bad_chans.tsv` with the following content:

| Channel  | Reason                                           |
|----------|--------------------------------------------------|
| EEG 053  | pre-existing (before mne-study-template was run) |
| MEG 1032 | auto-noisy                                       |
| MEG 2313 | auto-noisy                                       |
| MEG 2443 | pre-existing (before mne-study-template was run) |