### PR TITLE
Add recording kind to fwd, cov, inv, stc filenames

### DIFF
--- a/10-make_forward.py
+++ b/10-make_forward.py
@@ -23,9 +23,10 @@ logger = logging.getLogger('mne-study-template')
 
 @failsafe_run(on_error=on_error)
 def run_forward(subject, session=None):
+    kind = config.get_kind()
     deriv_path = config.get_subject_deriv_path(subject=subject,
                                                session=session,
-                                               kind=config.get_kind())
+                                               kind=kind)
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -38,7 +39,7 @@ def run_forward(subject, session=None):
 
     fname_evoked = op.join(deriv_path, bids_basename + '-ave.fif')
     fname_trans = op.join(deriv_path, 'sub-{}'.format(subject) + '-trans.fif')
-    fname_fwd = op.join(deriv_path, bids_basename + '-fwd.fif')
+    fname_fwd = op.join(deriv_path, f'{bids_basename}_{kind}-fwd.fif')
 
     msg = f'Input: {fname_evoked}, Output: {fname_fwd}'
     logger.info(gen_log_message(message=msg, step=10, subject=subject,
@@ -67,7 +68,7 @@ def run_forward(subject, session=None):
     evoked = mne.read_evokeds(fname_evoked, condition=0)
 
     # Here we only use 3-layers BEM only if EEG is available.
-    if config.get_kind() == 'eeg':
+    if kind == 'eeg':
         model = mne.make_bem_model(subject, ico=4,
                                    conductivity=(0.3, 0.006, 0.3),
                                    subjects_dir=config.get_fs_subjects_dir())

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -24,9 +24,10 @@ logger = logging.getLogger('mne-study-template')
 
 @failsafe_run(on_error=on_error)
 def run_covariance(subject, session=None):
+    kind = config.get_kind()
     deriv_path = config.get_subject_deriv_path(subject=subject,
                                                session=session,
-                                               kind=config.get_kind())
+                                               kind=kind)
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -44,7 +45,7 @@ def run_covariance(subject, session=None):
         extension = '-epo'
 
     fname_epo = op.join(deriv_path, bids_basename + '%s.fif' % extension)
-    fname_cov = op.join(deriv_path, bids_basename + '-cov.fif')
+    fname_cov = op.join(deriv_path, f'{bids_basename}_{kind}-cov.fif')
 
     msg = f'Input: {fname_epo}, Output: {fname_cov}'
     logger.info(gen_log_message(message=msg, step=11, subject=subject,

--- a/12-make_inverse.py
+++ b/12-make_inverse.py
@@ -24,9 +24,10 @@ logger = logging.getLogger('mne-study-template')
 
 @failsafe_run(on_error=on_error)
 def run_inverse(subject, session=None):
+    kind = config.get_kind()
     deriv_path = config.get_subject_deriv_path(subject=subject,
                                                session=session,
-                                               kind=config.get_kind())
+                                               kind=kind)
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -38,9 +39,9 @@ def run_inverse(subject, session=None):
                                        space=config.space)
 
     fname_ave = op.join(deriv_path, bids_basename + '-ave.fif')
-    fname_fwd = op.join(deriv_path, bids_basename + '-fwd.fif')
-    fname_cov = op.join(deriv_path, bids_basename + '-cov.fif')
-    fname_inv = op.join(deriv_path, bids_basename + '-inv.fif')
+    fname_fwd = op.join(deriv_path, f'{bids_basename}_{kind}-fwd.fif')
+    fname_cov = op.join(deriv_path, f'{bids_basename}_{kind}-cov.fif')
+    fname_inv = op.join(deriv_path, f'{bids_basename}_{kind}-inv.fif')
 
     evokeds = mne.read_evokeds(fname_ave)
     cov = mne.read_cov(fname_cov)
@@ -62,7 +63,8 @@ def run_inverse(subject, session=None):
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         fname_stc = op.join(deriv_path, '_'.join([bids_basename, cond_str,
-                                                  inverse_str, hemi_str]))
+                                                  inverse_str, kind,
+                                                  hemi_str]))
 
         stc = apply_inverse(evoked=evoked,
                             inverse_operator=inverse_operator,

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -22,9 +22,10 @@ logger = logging.getLogger('mne-study-template')
 
 
 def morph_stc(subject, session=None):
+    kind = config.get_kind()
     deriv_path = config.get_subject_deriv_path(subject=subject,
                                                session=session,
-                                               kind=config.get_kind())
+                                               kind=kind)
 
     bids_basename = make_bids_basename(subject=subject,
                                        session=session,
@@ -44,14 +45,15 @@ def morph_stc(subject, session=None):
         method = config.inverse_method
         cond_str = 'cond-%s' % condition.replace(op.sep, '')
         inverse_str = 'inverse-%s' % method
-        hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         morph_str = 'morph-fsaverage'
+        hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         fname_stc = op.join(deriv_path, '_'.join([bids_basename, cond_str,
-                                                  inverse_str, hemi_str]))
+                                                  inverse_str, kind,
+                                                  hemi_str]))
         fname_stc_fsaverage = op.join(deriv_path,
                                       '_'.join([bids_basename, cond_str,
                                                 inverse_str, morph_str,
-                                                hemi_str]))
+                                                kind, hemi_str]))
 
         stc = mne.read_source_estimate(fname_stc)
         morph = mne.compute_source_morph(
@@ -82,7 +84,6 @@ def main():
     mean_morphed_stcs = map(sum, zip(*all_morphed_stcs))
 
     deriv_path = config.deriv_root
-
     bids_basename = make_bids_basename(task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
@@ -90,6 +91,7 @@ def main():
                                        recording=config.rec,
                                        space=config.space)
 
+    kind = config.get_kind()
     for condition, this_stc in zip(config.conditions, mean_morphed_stcs):
         this_stc /= len(all_morphed_stcs)
 
@@ -102,7 +104,7 @@ def main():
         fname_stc_avg = op.join(deriv_path, '_'.join(['average',
                                                       bids_basename, cond_str,
                                                       inverse_str, morph_str,
-                                                      hemi_str]))
+                                                      kind, hemi_str]))
         this_stc.save(fname_stc_avg)
 
     msg = 'Completed Step 13: Grand-average source estimates'

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -211,7 +211,7 @@ def main():
             if mne.viz.get_3d_backend() is not None:
                 brain = stc.plot(views=['lat'], hemi='both',
                                  initial_time=peak_time,  backend='mayavi')
-                figs = [brain._figures]
+                figs = [brain._figures[0]]
                 captions = ['evoked.comment']
             else:
                 import matplotlib.pyplot as plt


### PR DESCRIPTION
If a dataset includes both, MEG and EEG data, we need a way to tell the different forward models, noise covariance matrices, inverse operators, and STCs apart by their filenames.

In line with most of the other existing code, I'm using `config.get_kind()` here (instead of `config.ch_types`), so currently, only separation by **kind** is possible and usability is limited. We will need to address this at a later time – it's beyond the scope of this PR, and currently not too urgent, I believe.