### PR TITLE
TESTS: Don't install any X11/3D related packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ jobs:
             name: Set BASH_ENV
             command: |
               echo "set -e" >> $BASH_ENV;
-              echo "export DISPLAY=:99" >> $BASH_ENV;
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
+              # echo "export DISPLAY=:99" >> $BASH_ENV;
 
         - restore_cache:
             keys:
@@ -42,24 +42,24 @@ jobs:
               pip install -e .
               cd ..
 
-        - run:
-            name: Spin up Xvfb
-            command: |
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+        # - run:
+        #     name: Spin up Xvfb
+        #     command: |
+        #       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
-        - run:
-            name: Install PyQt5 dependencies
-            command: |
-              sudo apt-get install libxkbcommon-x11-0
+        # - run:
+        #     name: Install PyQt5 dependencies
+        #     command: |
+        #       sudo apt-get install libxkbcommon-x11-0
 
-        - run:
-            name: Install 3D dependencies
-            command: |
-              pip install --user --upgrade --progress-bar off vtk
-              pip install --user --upgrade --progress-bar off mayavi
-              pip install --user --upgrade --progress-bar off PySurfer[save_movie]
+        # - run:
+        #     name: Install 3D dependencies
+        #     command: |
+        #       pip install --user --upgrade --progress-bar off vtk
+        #       pip install --user --upgrade --progress-bar off mayavi
+        #       pip install --user --upgrade --progress-bar off PySurfer[save_movie]
 
         - run:
             name: Install datalad to conveniently pull testing datasets


### PR DESCRIPTION
We currently don't make any use of them, and they were interfering with some of the tests for #114. (This is something we should definitely fix someday, but currently we don't need this functionality.)

I've just commented out the relevant portions of the Circle config, so we can easily re-enable things again.