### PR TITLE
Only epoch conditions the user requested to analyze; improve documentation

### DIFF
--- a/03-make_epochs.py
+++ b/03-make_epochs.py
@@ -88,10 +88,18 @@ def run_epochs(subject, session=None):
     msg = 'Epoching'
     logger.info(gen_log_message(message=msg, step=3, subject=subject,
                                 session=session))
-    epochs = mne.Epochs(raw, events, event_id, config.tmin, config.tmax,
-                        proj=True, picks=picks, baseline=config.baseline,
-                        preload=False, decim=config.decim,
-                        reject=config.get_reject())
+
+    # We construct separate Epochs objects for each condition. When done, we
+    # concatnate them.
+    epochs = list()
+    for condition in config.conditions:
+        e = mne.Epochs(raw, events, event_id, config.tmin, config.tmax,
+                       proj=True, picks=picks, baseline=config.baseline,
+                       preload=False, decim=config.decim,
+                       reject=config.get_reject())
+        epochs.append(e)
+
+    epochs = mne.concatenate_epochs(epochs)
 
     msg = 'Writing epochs to disk'
     logger.info(gen_log_message(message=msg, step=3, subject=subject,

--- a/config.py
+++ b/config.py
@@ -443,6 +443,27 @@ rename_events = dict()
 # EPOCHING
 # --------
 #
+#  `conditions`` : list
+#    The condition names to consider. This can either be name of the
+#    experimental condition as specified in the BIDS ``events.tsv`` file; or
+#    the name of condition *grouped*, if the condition names contain the
+#    (MNE-specific) group separator, ``/``. See the "Subselecting epochs"
+#    tutorial for more information: https://mne.tools/stable/auto_tutorials/epochs/plot_10_epochs_overview.html#subselecting-epochs  # noqa: 501
+#
+# Example
+# ~~~~~~~
+# >>> conditions = ['auditory/left', 'visual/left']
+# or
+# >>> conditions = ['auditory/left', 'auditory/right']
+# or
+# >>> conditions = ['auditory']  # All "auditory" conditions (left AND right)
+# or
+# >>> conditions = ['auditory', 'visual']
+# or
+# >>> conditions = ['left', 'right']
+
+conditions = ['left', 'right']
+
 # ``tmin``: float
 #    A float in seconds that gives the start time before event of an epoch.
 #
@@ -481,27 +502,6 @@ trigger_time_shift = 0.
 
 baseline = (None, 0)
 
-#  `conditions`` : list
-#    The condition names to consider. This can either be the keys of
-#    ``event_id``, or – if event names were specified with ``/`` for
-#    grouping – the name of the *grouped* condition (i.e., the
-#    condition name before or after that ``/`` that is shared between the
-#    respective conditions you wish to group). See the "Subselecting epochs"
-#    tutorial for more information: https://mne.tools/stable/auto_tutorials/epochs/plot_10_epochs_overview.html#subselecting-epochs  # noqa: 501
-#
-# Example
-# ~~~~~~~
-# >>> conditions = ['auditory/left', 'visual/left']
-# or
-# >>> conditions = ['auditory/left', 'auditory/right']
-# or
-# >>> conditions = ['auditory']
-# or
-# >>> conditions = ['auditory', 'visual']
-# or
-# >>> conditions = ['left', 'right']
-
-conditions = ['left', 'right']
 
 ###############################################################################
 # ARTIFACT REMOVAL


### PR DESCRIPTION
- Only epoch conditions we intend intend to process: Previously, we'd epoch based on **all** events in the data, and only filter down to the conditions in `config.conditions` when constructing Evokeds. Now, we only create the required epochs in the first place.
- Move `conditions` config setting up (first setting of the "Epoch" section – makes more sense that wat IMHO!), and improve (and slightly correct) its documentation
