### PR TITLE
WIP: Allow condition-specific baselines

### DIFF
--- a/03-make_epochs.py
+++ b/03-make_epochs.py
@@ -93,10 +93,10 @@ def run_epochs(subject, session=None):
     # concatnate them.
     epochs = list()
     for condition in config.conditions:
-        if isinstance(config.baseline, str):
-            baseline = config.baseline
-        else:  # Should be a dictionary.
+        if isinstance(config.baseline, dict):
             baseline = config.baseline[condition]
+        else:
+            baseline = config.baseline
 
         e = mne.Epochs(raw, events, event_id, config.tmin, config.tmax,
                        proj=True, picks=picks, baseline=baseline,

--- a/config.py
+++ b/config.py
@@ -443,6 +443,27 @@ rename_events = dict()
 # EPOCHING
 # --------
 #
+#  `conditions`` : list
+#    The condition names to consider. This can either be name of the
+#    experimental condition as specified in the BIDS ``events.tsv`` file; or
+#    the name of condition *grouped*, if the condition names contain the
+#    (MNE-specific) group separator, ``/``. See the "Subselecting epochs"
+#    tutorial for more information: https://mne.tools/stable/auto_tutorials/epochs/plot_10_epochs_overview.html#subselecting-epochs  # noqa: 501
+#
+# Example
+# ~~~~~~~
+# >>> conditions = ['auditory/left', 'visual/left']
+# or
+# >>> conditions = ['auditory/left', 'auditory/right']
+# or
+# >>> conditions = ['auditory']  # All "auditory" conditions (left AND right)
+# or
+# >>> conditions = ['auditory', 'visual']
+# or
+# >>> conditions = ['left', 'right']
+
+conditions = ['left', 'right']
+
 # ``tmin``: float
 #    A float in seconds that gives the start time before event of an epoch.
 #
@@ -498,27 +519,6 @@ trigger_time_shift = 0.
 
 baseline = (None, 0)
 
-#  `conditions`` : list
-#    The condition names to consider. This can either be the keys of
-#    ``event_id``, or – if event names were specified with ``/`` for
-#    grouping – the name of the *grouped* condition (i.e., the
-#    condition name before or after that ``/`` that is shared between the
-#    respective conditions you wish to group). See the "Subselecting epochs"
-#    tutorial for more information: https://mne.tools/stable/auto_tutorials/epochs/plot_10_epochs_overview.html#subselecting-epochs  # noqa: 501
-#
-# Example
-# ~~~~~~~
-# >>> conditions = ['auditory/left', 'visual/left']
-# or
-# >>> conditions = ['auditory/left', 'auditory/right']
-# or
-# >>> conditions = ['auditory']
-# or
-# >>> conditions = ['auditory', 'visual']
-# or
-# >>> conditions = ['left', 'right']
-
-conditions = ['left', 'right']
 
 ###############################################################################
 # ARTIFACT REMOVAL

--- a/config.py
+++ b/config.py
@@ -494,8 +494,8 @@ tmax = 0.5
 trigger_time_shift = 0.
 
 # ``baseline`` : tuple | dict of tuples | None
-#    It specifies how to baseline-correct the epochs; if None, no baseline is
-#    applied.
+#    It specifies how to baseline-correct the epochs; if ``None``, no baseline
+#    correction is applied.
 #
 #    When a tuple is passed, its first element corresponds to the beginning,
 #    and its second element to the end of the baseline period (both endpoints

--- a/tests/configs/config_ds001971.py
+++ b/tests/configs/config_ds001971.py
@@ -18,6 +18,7 @@ interactive = False
 ch_types = ['eeg']
 reject = {'eeg': 150e-6}
 conditions = ['left', 'right']
+baseline = (None, 0)
 decoding_conditions = [('left', 'right')]
 use_ssp = False
 use_ica = False

--- a/tests/configs/config_eeg_matchingpennies.py
+++ b/tests/configs/config_eeg_matchingpennies.py
@@ -15,6 +15,8 @@ ch_types = ['eeg']
 interactive = False
 reject = {'eeg': 150e-6}
 conditions = ['left', 'right']
+baseline = dict(left=(-0.2, 0),
+                right=(-0.15, 0))
 decoding_conditions = [('left', 'right')]
 use_ssp = False
 use_ica = False


### PR DESCRIPTION
Users can now set different baselines for different conditions by setting `config.baseline` to a dict with condition names as keys and `(tmin, tmax)` tuples as values.

Also improves documentation of `config.conditions` and moves this setting to the very top of the `EPOCHING` section.