### PR TITLE
Use MNE's default cross-validation strategies in decoding, noise covariance estimation

### DIFF
--- a/08-sliding_estimator.py
+++ b/08-sliding_estimator.py
@@ -77,9 +77,7 @@ def run_time_decoding(subject, condition1, condition2, session=None):
                       LogisticRegression(solver='liblinear',
                                          random_state=config.random_state)),
         scoring=config.decoding_metric, n_jobs=config.N_JOBS)
-    cv = StratifiedKFold(random_state=config.random_state,
-                         n_splits=config.decoding_n_splits)
-    scores = cross_val_multiscore(se, X=X, y=y, cv=cv)
+    scores = cross_val_multiscore(se, X=X, y=y, cv=config.decoding_n_splits)
 
     # let's save the scores now
     a_vs_b = '%s_vs_%s' % (condition1, condition2)

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -50,13 +50,8 @@ def compute_cov_from_epochs(subject, session, tmin, tmax):
                                 session=session))
 
     epochs = mne.read_epochs(epo_fname, preload=True)
-
-    # Do not shuffle the data before splitting into train and test samples.
-    # Perform a block cross-validation instead to maintain autocorrelated
-    # noise.
-    cv = KFold(3, shuffle=False)
     cov = mne.compute_covariance(epochs, tmin=tmin, tmax=tmax, method='shrunk',
-                                 cv=cv, rank='info')
+                                 rank='info')
     cov.save(cov_fname)
 
 
@@ -88,13 +83,7 @@ def compute_cov_from_empty_room(subject, session):
                                 session=session))
 
     raw_er = mne.io.read_raw_fif(raw_er_fname, preload=True, **extra_params)
-
-    # Do not shuffle the data before splitting into train and test samples.
-    # Perform a block cross-validation instead to maintain autocorrelated
-    # noise.
-    cv = KFold(3, shuffle=False)
-    cov = mne.compute_raw_covariance(raw_er, method='shrunk', cv=cv,
-                                     rank='info')
+    cov = mne.compute_raw_covariance(raw_er, method='shrunk', rank='info')
     cov.save(cov_fname)
 
 


### PR DESCRIPTION
Do not construct custom cross-validation objects anymore.

- Use MNE's default CV strategy while decoding: only pass the number of splits, but otherwise leave everything else to MNE to decide.
- Use MNE's default CV strategy (incl. number of splits) when estimating the noise covariance.

Current user-facing behavior remains unchanged.

I believe the only reason the CV objects were initially created was to allow for shuffling (which MNE does not do by default). Following our discussions in #141 and #73, we explicitly want to **avoid shuffling**: MNE does the right thing for us already. So let's drop the manually created CV objects.