### PR TITLE
[MRG] Treat grand-averaged data as if coming from "sub-average" & make derivatives naming more consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
               # echo "export DISPLAY=:99" >> $BASH_ENV;
+              shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
 
         - restore_cache:
             keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
               # echo "export DISPLAY=:99" >> $BASH_ENV;
+              echo "shopt -s globstar" >> $BASH_ENV;  # Enable recursive globbing via **
 
         - restore_cache:
             keys:
@@ -99,7 +100,6 @@ jobs:
                export DS=ds000246
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -109,7 +109,6 @@ jobs:
                export DS=ds000248
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -119,7 +118,6 @@ jobs:
                export DS=ds001810
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -129,7 +127,6 @@ jobs:
                export DS=eeg_matchingpennies
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -139,7 +136,6 @@ jobs:
                export DS=somato
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV;
               echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
               # echo "export DISPLAY=:99" >> $BASH_ENV;
-              shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
 
         - restore_cache:
             keys:
@@ -100,6 +99,7 @@ jobs:
                export DS=ds000246
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
+               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -109,6 +109,7 @@ jobs:
                export DS=ds000248
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
+               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -118,6 +119,7 @@ jobs:
                export DS=ds001810
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
+               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -127,6 +129,7 @@ jobs:
                export DS=eeg_matchingpennies
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
+               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
@@ -135,7 +138,8 @@ jobs:
             command: |
                export DS=somato
                python tests/run_tests.py ${DS}
-               # mkdir ~/reports/${DS}
+               mkdir ~/reports/${DS}
+               shopt -s globstar  # Enable recursive globbing via **, e.g. */**/*.foo
                cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
                export DS=ds000246
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -108,7 +108,7 @@ jobs:
                export DS=ds000248
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -117,7 +117,7 @@ jobs:
                export DS=ds001810
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -126,7 +126,7 @@ jobs:
                export DS=eeg_matchingpennies
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -135,7 +135,7 @@ jobs:
                export DS=somato
                python tests/run_tests.py ${DS}
                # mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/**/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,7 @@ jobs:
                export DS=ds000246
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -109,8 +108,7 @@ jobs:
                export DS=ds000248
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -119,8 +117,7 @@ jobs:
                export DS=ds001810
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -129,8 +126,7 @@ jobs:
                export DS=eeg_matchingpennies
                python tests/run_tests.py ${DS}
                mkdir ~/reports/${DS}
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - run:
@@ -139,8 +135,7 @@ jobs:
                export DS=somato
                python tests/run_tests.py ${DS}
                # mkdir ~/reports/${DS}
-               # cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/report_*.html ~/reports/${DS}/
-               # cp ~/mne_data/${DS}/derivatives/mne-study-template/report_average_*.html ~/reports/${DS}/
+               cp ~/mne_data/${DS}/derivatives/mne-study-template/*/*/*_report.html ~/reports/${DS}/
                rm -rf ~/mne_data/${DS}/derivatives/mne-study-template/
 
         - store_artifacts:

--- a/05a-apply_ica.py
+++ b/05a-apply_ica.py
@@ -49,7 +49,7 @@ def apply_ica(subject, run, session):
                                        prefix=deriv_path)
 
     fname_in = bids_basename.copy().update(suffix='epo.fif')
-    fname_out = bids_basename.copy().update(suffix='cleaned-epo.fif')
+    fname_out = bids_basename.copy().update(suffix='cleaned_epo.fif')
 
     # load epochs to reject ICA components
     epochs = mne.read_epochs(fname_in, preload=True)

--- a/05b-apply_ssp.py
+++ b/05b-apply_ssp.py
@@ -42,7 +42,7 @@ def apply_ssp(subject, session=None):
                                        prefix=deriv_path)
 
     fname_in = bids_basename.copy().update(suffix='epo.fif')
-    fname_out = bids_basename.copy().update(suffix='cleaned-epo.fif')
+    fname_out = bids_basename.copy().update(suffix='cleaned_epo.fif')
 
     epochs = mne.read_epochs(fname_in, preload=True)
 

--- a/06-make_evoked.py
+++ b/06-make_evoked.py
@@ -38,7 +38,7 @@ def run_evoked(subject, session=None):
                                        prefix=deriv_path)
 
     if config.use_ica or config.use_ssp:
-        suffix = 'cleaned-epo.fif'
+        suffix = 'cleaned_epo.fif'
     else:
         suffix = 'epo.fif'
 

--- a/07-group_average_sensors.py
+++ b/07-group_average_sensors.py
@@ -6,6 +6,7 @@
 The M/EEG-channel data are averaged for group averages.
 """
 
+import os
 import os.path as op
 from collections import defaultdict
 import logging
@@ -60,9 +61,23 @@ for idx, evokeds in all_evokeds.items():
         evokeds, interpolate_bads=config.interpolate_bads_grand_average
     )  # Combine subjects
 
-extension = 'grand_average-ave'
-fname_out = op.join(config.bids_root, 'derivatives', config.PIPELINE_NAME,
-                    '{0}_{1}.fif'.format(config.study_name, extension))
+subject = 'average'
+deriv_path = config.get_subject_deriv_path(subject=subject,
+                                           session=session,
+                                           kind=config.get_kind())
+if not op.exists(deriv_path):
+    os.makedirs(deriv_path)
+
+fname_out = make_bids_basename(subject=subject,
+                               session=session,
+                               task=config.get_task(),
+                               acquisition=config.acq,
+                               run=None,
+                               processing=config.proc,
+                               recording=config.rec,
+                               space=config.space,
+                               prefix=deriv_path,
+                               suffix='ave.fif')
 
 msg = f'Saving grand-averaged sensor data: {fname_out}'
 logger.info(gen_log_message(message=msg, step=7, subject=subject,

--- a/09-time_frequency.py
+++ b/09-time_frequency.py
@@ -46,7 +46,7 @@ def run_time_frequency(subject, session=None):
                                        prefix=deriv_path)
 
     if config.use_ica or config.use_ssp:
-        suffix = 'cleaned-epo.fif'
+        suffix = 'cleaned_epo.fif'
     else:
         suffix = 'epo.fif'
 

--- a/10-make_forward.py
+++ b/10-make_forward.py
@@ -38,7 +38,7 @@ def run_forward(subject, session=None):
                                        prefix=deriv_path)
 
     fname_evoked = bids_basename.copy().update(suffix='ave.fif')
-    fname_trans = op.join(deriv_path, f'sub-{subject}-trans.fif')
+    fname_trans = bids_basename.copy().update(suffix='trans.fif')
     fname_fwd = bids_basename.copy().update(suffix='fwd.fif')
 
     msg = f'Input: {fname_evoked}, Output: {fname_fwd}'

--- a/11-make_cov.py
+++ b/11-make_cov.py
@@ -38,7 +38,7 @@ def compute_cov_from_epochs(subject, session, tmin, tmax):
                                        prefix=deriv_path)
 
     if config.use_ica or config.use_ssp:
-        suffix = 'cleaned-epo.fif'
+        suffix = 'cleaned_epo.fif'
     else:
         suffix = 'epo.fif'
 

--- a/12-make_inverse.py
+++ b/12-make_inverse.py
@@ -59,11 +59,11 @@ def run_inverse(subject, session=None):
         method = config.inverse_method
         pick_ori = None
 
-        cond_str = 'cond-%s' % condition.replace(op.sep, '')
+        cond_str = 'cond-%s' % condition.replace(op.sep, '').replace('_', '-')
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
-        fname_stc = '_'.join([str(bids_basename.update(suffix=None)),
-                              cond_str, inverse_str, hemi_str])
+        fname_stc = (bids_basename.copy()
+                     .update(suffix=f'{cond_str}_{inverse_str}_{hemi_str}'))
 
         stc = apply_inverse(evoked=evoked,
                             inverse_operator=inverse_operator,

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -81,11 +81,18 @@ def main():
     mean_morphed_stcs = map(sum, zip(*all_morphed_stcs))
 
     subject = 'average'
+    # XXX to fix
+    if config.get_sessions():
+        session = config.get_sessions()[0]
+    else:
+        session = None
+
     deriv_path = config.get_subject_deriv_path(subject=subject,
-                                               session=None,
+                                               session=session,
                                                kind=config.get_kind())
 
     bids_basename = make_bids_basename(subject=subject,
+                                       session=session,
                                        task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,

--- a/13-group_average_source.py
+++ b/13-group_average_source.py
@@ -39,14 +39,16 @@ def morph_stc(subject, session=None):
     morphed_stcs = []
     for condition in config.conditions:
         method = config.inverse_method
-        cond_str = 'cond-%s' % condition.replace(op.sep, '')
+        cond_str = 'cond-%s' % condition.replace(op.sep, '').replace('_', '-')
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         morph_str = 'morph-fsaverage'
-        fname_stc = '_'.join([str(bids_basename), cond_str,
-                              inverse_str, hemi_str])
-        fname_stc_fsaverage = '_'.join([str(bids_basename), cond_str,
-                                        inverse_str, morph_str, hemi_str])
+
+        fname_stc = (bids_basename.copy()
+                     .update(suffix=f'{cond_str}_{inverse_str}_{hemi_str}'))
+        fname_stc_fsaverage = (bids_basename.copy()
+                               .update(suffix=f'{cond_str}_{inverse_str}_'
+                                              f'{morph_str}_{hemi_str}'))
 
         stc = mne.read_source_estimate(fname_stc)
         morph = mne.compute_source_morph(
@@ -78,28 +80,32 @@ def main():
                         zip(all_morphed_stcs, config.get_subjects())]
     mean_morphed_stcs = map(sum, zip(*all_morphed_stcs))
 
-    deriv_path = config.deriv_root
-    bids_basename = make_bids_basename(task=config.get_task(),
+    subject = 'average'
+    deriv_path = config.get_subject_deriv_path(subject=subject,
+                                               session=None,
+                                               kind=config.get_kind())
+
+    bids_basename = make_bids_basename(subject=subject,
+                                       task=config.get_task(),
                                        acquisition=config.acq,
                                        run=None,
                                        processing=config.proc,
                                        recording=config.rec,
-                                       space=config.space)
+                                       space=config.space,
+                                       prefix=deriv_path)
 
     for condition, this_stc in zip(config.conditions, mean_morphed_stcs):
         this_stc /= len(all_morphed_stcs)
 
         method = config.inverse_method
-        cond_str = 'cond-%s' % condition.replace(op.sep, '')
+        cond_str = 'cond-%s' % condition.replace(op.sep, '').replace('_', '-')
         inverse_str = 'inverse-%s' % method
         hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
         morph_str = 'morph-fsaverage'
 
-        fname_stc_avg = op.join(deriv_path, '_'.join(['average',
-                                                      str(bids_basename),
-                                                      cond_str,
-                                                      inverse_str, morph_str,
-                                                      hemi_str]))
+        fname_stc_avg = (bids_basename.copy()
+                         .update(suffix=f'{cond_str}_{inverse_str}_'
+                                        f'{morph_str}_{hemi_str}'))
         this_stc.save(fname_stc_avg)
 
     msg = 'Completed Step 13: Grand-average source estimates'

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -230,10 +230,17 @@ def main():
 
     # Group report
     subject = 'average'
+    # XXX to fix
+    if config.get_sessions():
+        session = config.get_sessions()[0]
+    else:
+        session = None
+
     deriv_path = config.get_subject_deriv_path(subject=subject,
-                                               session=None,
+                                               session=session,
                                                kind=config.get_kind())
     evoked_fname = make_bids_basename(subject=subject,
+                                      session=session,
                                       task=config.get_task(),
                                       acquisition=config.acq,
                                       run=None,

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -149,7 +149,7 @@ def run_report(subject, session=None):
                                         subject=subject, session=session))
 
         for evoked in evokeds:
-            msg = 'Rendering inverse solution for {evoked.comment} …'
+            msg = f'Rendering inverse solution for {evoked.comment} …'
             logger.info(gen_log_message(message=msg, step=99,
                                         subject=subject, session=session))
 

--- a/99-make_reports.py
+++ b/99-make_reports.py
@@ -88,10 +88,11 @@ def run_report(subject, session=None):
                                        run=None,
                                        processing=config.proc,
                                        recording=config.rec,
-                                       space=config.space)
+                                       space=config.space,
+                                       prefix=deriv_path)
 
-    fname_ave = op.join(deriv_path, bids_basename.update(suffix='ave.fif'))
-    fname_trans = op.join(deriv_path, f'sub-{subject}-trans.fif')
+    fname_ave = bids_basename.copy().update(suffix='ave.fif')
+    fname_trans = bids_basename.copy().update(suffix='trans.fif')
     subjects_dir = config.get_fs_subjects_dir()
     if op.exists(fname_trans):
         rep = mne.Report(info_fname=fname_ave, subject=subject,
@@ -162,11 +163,12 @@ def run_report(subject, session=None):
             cond_str = 'cond-%s' % evoked.comment.replace(op.sep, '')
             inverse_str = 'inverse-%s' % method
             hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
-            fname_stc = op.join(deriv_path, '_'.join([str(bids_basename),
-                                                      cond_str, inverse_str,
-                                                      hemi_str]))
 
-            if op.exists(fname_stc + "-lh.stc"):
+            fname_stc = (bids_basename.copy()
+                         .update(suffix=f'{cond_str}_{inverse_str}_'
+                                        f'{hemi_str}'))
+
+            if op.exists(str(fname_stc) + "-lh.stc"):
                 stc = mne.read_source_estimate(fname_stc, subject)
                 _, peak_time = stc.get_peak()
 
@@ -212,12 +214,7 @@ def run_report(subject, session=None):
                                          '(after filtering)',
                                 section='Empty-Room')
 
-    if config.get_task():
-        task_str = '_task-%s' % config.get_task()
-    else:
-        task_str = ''
-
-    fname_report = op.join(deriv_path, 'report%s.html' % task_str)
+    fname_report = bids_basename.copy().update(suffix='report.html')
     rep.save(fname=fname_report, open_browser=False, overwrite=True)
 
 
@@ -232,20 +229,25 @@ def main():
              itertools.product(config.get_subjects(), config.get_sessions()))
 
     # Group report
-    evoked_fname = op.join(config.bids_root, 'derivatives',
-                           config.PIPELINE_NAME,
-                           '%s_grand_average-ave.fif' % config.study_name)
+    subject = 'average'
+    deriv_path = config.get_subject_deriv_path(subject=subject,
+                                               session=None,
+                                               kind=config.get_kind())
+    evoked_fname = make_bids_basename(subject=subject,
+                                      task=config.get_task(),
+                                      acquisition=config.acq,
+                                      run=None,
+                                      processing=config.proc,
+                                      recording=config.rec,
+                                      space=config.space,
+                                      prefix=deriv_path,
+                                      suffix='ave.fif')
+
     rep = mne.Report(info_fname=evoked_fname, subject='fsaverage',
                      subjects_dir=config.get_fs_subjects_dir())
     evokeds = mne.read_evokeds(evoked_fname)
     deriv_path = config.deriv_root
     subjects_dir = config.get_fs_subjects_dir()
-    bids_basename = make_bids_basename(task=config.get_task(),
-                                       acquisition=config.acq,
-                                       run=None,
-                                       processing=config.proc,
-                                       recording=config.rec,
-                                       space=config.space)
 
     method = config.inverse_method
     inverse_str = 'inverse-%s' % method
@@ -280,18 +282,19 @@ def main():
     for condition, evoked in zip(conditions, evokeds):
         if condition in config.conditions:
             caption = f'Average: {condition}'
-            cond_str = 'cond-%s' % condition.replace(op.sep, '')
+            cond_str = 'cond-%s' % (condition
+                                    .replace(op.sep, '')
+                                    .replace('_', '-'))
         else:  # It's a contrast of two conditions.
             # XXX Will change once we process contrasts here too
             continue
 
         section = 'Source'
-        fname_stc_avg = op.join(deriv_path, '_'.join(['average',
-                                                      str(bids_basename),
-                                                      cond_str, inverse_str,
-                                                      morph_str, hemi_str]))
+        fname_stc_avg = (evoked_fname.copy()
+                         .update(suffix=f'{cond_str}_{inverse_str}_'
+                                        f'{morph_str}_{hemi_str}'))
 
-        if op.exists(fname_stc_avg + "-lh.stc"):
+        if op.exists(str(fname_stc_avg) + "-lh.stc"):
             stc = mne.read_source_estimate(fname_stc_avg, subject='fsaverage')
             _, peak_time = stc.get_peak()
 
@@ -325,12 +328,9 @@ def main():
 
             del peak_time
 
-    if config.get_task():
-        task_str = '_task-%s' % config.get_task()
-    else:
-        task_str = ''
-
-    fname_report = op.join(deriv_path, 'report_average%s.html' % task_str)
+    fname_report = (evoked_fname.copy()
+                    .update(task=config.get_task(),
+                            suffix='report.html'))
     rep.save(fname=fname_report, open_browser=False, overwrite=True)
 
     msg = 'Completed Step 99: Create reports'

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -68,7 +68,7 @@ TEST_SUITE = {
     'ds000248': ('config_ds000248', sensor, source, report),
     'ds001810': ('config_ds001810', sensor, report),
     'eeg_matchingpennies': ('config_eeg_matchingpennies', sensor, report),
-    'somato': ('config_somato', sensor, source),
+    'somato': ('config_somato', sensor, source, report),
 }
 
 


### PR DESCRIPTION
As discussed in https://github.com/mne-tools/mne-bids/issues/454#issuecomment-653858194

This also allows us to use BIDSPath in more (all?) places now when creating paths.

Also cleans up / unifies some naming schemes.

Example derivatives folder after running the study-template on the somato dataset:

```
.
├── dataset_description.json
├── sub-01
│   └── meg
│       ├── sub-01_task-somato_ave.fif
│       ├── sub-01_task-somato_cleaned-epo.fif
│       ├── sub-01_task-somato_cond-somato-event1_inverse-dSPM_hemi-lh.stc
│       ├── sub-01_task-somato_cond-somato-event1_inverse-dSPM_hemi-rh.stc
│       ├── sub-01_task-somato_cond-somato-event1_inverse-dSPM_morph-fsaverage_hemi-lh.stc
│       ├── sub-01_task-somato_cond-somato-event1_inverse-dSPM_morph-fsaverage_hemi-rh.stc
│       ├── sub-01_task-somato_cov.fif
│       ├── sub-01_task-somato_epo.fif
│       ├── sub-01_task-somato_filt_raw.fif
│       ├── sub-01_task-somato_fwd.fif
│       ├── sub-01_task-somato_inv.fif
│       ├── sub-01_task-somato_nosss_raw.fif
│       ├── sub-01_task-somato_report.html
│       ├── sub-01_task-somato_ssp-proj.fif
│       └── sub-01_task-somato_trans.fif
└── sub-average
    └── meg
        ├── sub-average_task-somato_ave.fif
        ├── sub-average_task-somato_cond-somato-event1_inverse-dSPM_morph-fsaverage_hemi-lh.stc
        ├── sub-average_task-somato_cond-somato-event1_inverse-dSPM_morph-fsaverage_hemi-rh.stc
        └── sub-average_task-somato_report.html

```

**Note that this depends on https://github.com/mne-tools/mne-bids/pull/470, and tests will fail until this has been merged upstream.**