### PR TITLE
Add support for applying an EEG template montage

### DIFF
--- a/01-import_and_maxfilter.py
+++ b/01-import_and_maxfilter.py
@@ -224,6 +224,15 @@ def load_data(bids_basename):
     if hasattr(raw, 'fix_mag_coil_types'):
         raw.fix_mag_coil_types()
 
+    montage_name = config.eeg_template_montage
+    if config.get_kind() == 'eeg' and montage_name:
+        msg = (f'Setting EEG channel locatiions to template montage: '
+               f'{montage_name}.')
+        logger.info(gen_log_message(message=msg, step=1, subject=subject,
+                                    session=session))
+        montage = mne.channels.make_standard_montage(montage_name)
+        raw.set_montage(montage, on_missing='warn')
+
     return raw
 
 

--- a/config.py
+++ b/config.py
@@ -143,6 +143,34 @@ exclude_subjects = []
 ch_types = []
 
 ###############################################################################
+# Apply EEG template montage?
+# ---------------------------
+#
+# In situations where you wish to process EEG data and no individual
+# digitization points (measured channel locations) are available, you can apply
+# a "template" montage. This means we will assume the EEG cap was placed
+# either according to an international system like 10/20, or as suggested by
+# the cap manufacturers in their respective manual.
+#
+# Please be aware that the actual cap placement most likely deviated somewhat
+# from template, and, therefore, source reconstruction may be impaired.
+#
+# ``eeg_template_montage`` : None | str
+#   If ``None``, do not apply a template montage. If a string, must be the
+#   name of a built-in template montage in MNE-Python.
+#   You can find an overview of supported template montages at
+#   https://mne.tools/stable/generated/mne.channels.make_standard_montage.html
+#
+# Example
+# ~~~~~~~
+# Do not apply template montage:
+# >>> eeg_template_montage = None
+# Apply 64-channel Biosemi 10/20 template montage:
+# >>> eeg_template_montage = 'biosemi64'
+eeg_template_montage = None
+
+
+###############################################################################
 # DEFINE ADDITIONAL CHANNELS
 # --------------------------
 # needed for 01-import_and_maxfilter.py

--- a/config.py
+++ b/config.py
@@ -153,7 +153,7 @@ ch_types = []
 # the cap manufacturers in their respective manual.
 #
 # Please be aware that the actual cap placement most likely deviated somewhat
-# from template, and, therefore, source reconstruction may be impaired.
+# from the template, and, therefore, source reconstruction may be impaired.
 #
 # ``eeg_template_montage`` : None | str
 #   If ``None``, do not apply a template montage. If a string, must be the

--- a/tests/configs/config_ds001810.py
+++ b/tests/configs/config_ds001810.py
@@ -16,6 +16,7 @@ study_name = 'ds001810'
 task = 'attentionalblink'
 interactive = False
 ch_types = ['eeg']
+eeg_template_montage = 'biosemi64'
 reject = {'eeg': 150e-6}
 conditions = ['61510', '61511']
 contrasts = [('61510', '61511')]


### PR DESCRIPTION
For datasets where no digitizer information (i.e., measured sensor locations) are available, users may wish to use the template montage supplied by the manufacturer (or simply calculated according to the 10/20 etc. systems). This PR adds the `eeg_template_montage` configuration setting that allows to use MNE-Python's built-in templates.

-----
IMHO, this again highlights an issue with the current BIDS specification: that it's not allowed to store montage / channel locations in the dataset if the locations are from a template and not actually measured. For the dataset I'm using for testing here, `ds001810`, I had to dig into `*_eeg.json` to find:

```
        "CapManufacturer": "Biosemi",
        "CapManufacturersModelName": "CAP 64 10/20",
```
and then I had to start searching for the template – fortunately, it's included in MNE-Python :) But this brings me to the next issue with not including the template / template locations in BIDS: if MNE **hadn't** included this particular template, I would have had to juggle yet another file that I have to store somewhere (since it's not included in the original dataset). This is just asking for problems… :) 

cc @sappelhoff 