### PR TITLE
MRG, ENH: Conduct dimensionality reduction before ICA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
               conda update -n base -c defaults conda
               pip install numpy scipy pandas json_tricks matplotlib seaborn nibabel coloredlogs python-picard
               pip install -U scikit-learn
-              pip install --upgrade https://api.github.com/repos/mne-tools/mne-python/zipball/master
+              # pip install --upgrade https://api.github.com/repos/mne-tools/mne-python/zipball/master
+              # XXX remove before merging
+              pip install https://github.com/hoechenberger/mne-python/archive/ica-max_pca_components.zip
               git clone https://github.com/mne-tools/mne-bids.git --depth 1
               cd mne-bids
               pip install -e .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,7 @@ jobs:
               conda update -n base -c defaults conda
               pip install numpy scipy pandas json_tricks matplotlib seaborn nibabel coloredlogs python-picard
               pip install -U scikit-learn
-              # pip install --upgrade https://api.github.com/repos/mne-tools/mne-python/zipball/master
-              # XXX remove before merging
-              pip install https://github.com/hoechenberger/mne-python/archive/ica-max_pca_components.zip
+              pip install --upgrade https://api.github.com/repos/mne-tools/mne-python/zipball/master
               git clone https://github.com/mne-tools/mne-bids.git --depth 1
               cd mne-bids
               pip install -e .

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -305,8 +305,13 @@ def run_ica(subject, session=None):
                                   psd_args={'fmax': 60},
                                   show=False)
 
+        caption = f'IC {component_num}'
+        if component_num in eog_ics:
+            caption += ' (EOG)'
+        elif component_num in ecg_ics:
+            caption += ' (ECG)'
         report.add_figs_to_section(fig, section=f'sub-{subject}',
-                                   captions=f'IC {component_num}')
+                                   captions=caption)
 
     open_browser = True if config.interactive else False
     report.save(report_fname, overwrite=True, open_browser=open_browser)

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -106,7 +106,7 @@ def fit_ica(epochs, subject, session):
         fit_params = None
 
     ica = ICA(method=config.ica_algorithm, random_state=config.random_state,
-              max_pca_components=config.ica_max_pca_components,
+              n_components=config.ica_n_components, max_pca_components=0.9999,
               fit_params=fit_params, max_iter=config.ica_max_iterations)
 
     ica.fit(epochs, decim=config.ica_decim)

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -306,7 +306,9 @@ def run_ica(subject, session=None):
                                   show=False)
 
         caption = f'IC {component_num}'
-        if component_num in eog_ics:
+        if component_num in eog_ics and component_num in ecg_ics:
+            caption += ' (EOG & ECG)'
+        elif component_num in eog_ics:
             caption += ' (EOG)'
         elif component_num in ecg_ics:
             caption += ' (ECG)'

--- a/04a-run_ica.py
+++ b/04a-run_ica.py
@@ -106,8 +106,8 @@ def fit_ica(epochs, subject, session):
         fit_params = None
 
     ica = ICA(method=config.ica_algorithm, random_state=config.random_state,
-              n_components=config.ica_n_components, fit_params=fit_params,
-              max_iter=config.ica_max_iterations)
+              max_pca_components=config.ica_max_pca_components,
+              fit_params=fit_params, max_iter=config.ica_max_iterations)
 
     ica.fit(epochs, decim=config.ica_decim)
 

--- a/config.py
+++ b/config.py
@@ -618,7 +618,13 @@ ica_l_freq = 1.
 
 ica_max_iterations = 200
 
-# ``ica_n_components`` : None | float | int
+# ``ica_max_pca_components`` : float | int | None
+#
+#   MNE conducts ICA as a sort of a two-step procedure: First, a PCA is run
+#   on the data; and in the second step, the data is passed to the actual ICA.
+#   This allows us to e.g. reduce dimensionality of the data using PCA
+#   before submitting it to ICA.
+#
 #   If int, specifies the number of principal components that are passed to the
 #   ICA algorithm.
 #
@@ -626,9 +632,14 @@ ica_max_iterations = 200
 #   explained variance less than the value specified here will be passed to
 #   ICA.
 #
-#   If None, all principal components will be used.
+#   If ``None``, **all** principal components will be used.
+#
+#   It is a good idea to set this to a float smaller zero, or an int smaller
+#   than the number of channels in the data, as this will avoid running into
+#   issues due to rank deficiency, while also – depending on the dataset –
+#   dramatically reducing processing time.
 
-ica_n_components = 0.999
+ica_max_pca_components = 0.999
 
 # ``ica_decim`` : None | None
 #    The decimation parameter to compute ICA. If 5 it means

--- a/config.py
+++ b/config.py
@@ -618,15 +618,24 @@ ica_l_freq = 1.
 
 ica_max_iterations = 200
 
-# ``ica_max_pca_components`` : float | int | None
+# ``ica_n_components`` : float | int | None
 #
 #   MNE conducts ICA as a sort of a two-step procedure: First, a PCA is run
 #   on the data; and in the second step, the data is passed to the actual ICA.
-#   This allows us to e.g. reduce dimensionality of the data using PCA
-#   before submitting it to ICA.
+#   This allows us to reduce dimensionality of the data using PCA, before
+#   submitting the data to ICA. We will always reduce dimensionality such that
+#   the remaining principal components explain about 99.99% of the variance in
+#   the data; this ensures that any components **not** contributing to variance
+#   will be dropped to avoid working with rank-deficient data.
+#
+#   As said above, after this PCA step, the actual ICA takes place. You can
+#   control how many principal components to pass to the ICA algorithm, thereby
+#   determining how many independent components to fit.
 #
 #   If int, specifies the number of principal components that are passed to the
-#   ICA algorithm.
+#   ICA algorithm, which will also be the number of independent components to
+#   fit. It must not be greater than the rank of your data (which is typically
+#   the number of channels, but may be less in some cases).
 #
 #   If float between 0 and 1, all principal components with cumulative
 #   explained variance less than the value specified here will be passed to
@@ -634,12 +643,9 @@ ica_max_iterations = 200
 #
 #   If ``None``, **all** principal components will be used.
 #
-#   It is a good idea to set this to a float smaller zero, or an int smaller
-#   than the number of channels in the data, as this will avoid running into
-#   issues due to rank deficiency, while also – depending on the dataset –
-#   dramatically reducing processing time.
+#   This setting may drastically alter the time required to compute ICA.
 
-ica_max_pca_components = 0.999
+ica_n_components = 0.8
 
 # ``ica_decim`` : None | None
 #    The decimation parameter to compute ICA. If 5 it means

--- a/config.py
+++ b/config.py
@@ -659,7 +659,7 @@ ica_ctps_ecg_threshold = 0.1
 #   that more ICs will be identified as EOG-related. If too low, the
 #   false-alarm rate increases dramatically.
 
-ica_eog_threshold = 2.
+ica_eog_threshold = 3.0
 
 ###############################################################################
 # DECODING

--- a/tests/configs/config_ds000248_ica.py
+++ b/tests/configs/config_ds000248_ica.py
@@ -25,8 +25,8 @@ reject = dict(mag=3000e-15,
 
 use_ssp = False
 use_ica = True
-ica_max_pca_components = 0.80
 ica_l_freq = 1.0
+ica_n_components = 0.8
 ica_max_iterations = 500
 
 interactive = False

--- a/tests/configs/config_ds000248_ica.py
+++ b/tests/configs/config_ds000248_ica.py
@@ -25,7 +25,7 @@ reject = dict(mag=3000e-15,
 
 use_ssp = False
 use_ica = True
-ica_n_components = 0.80
+ica_max_pca_components = 0.80
 ica_l_freq = 1.0
 ica_max_iterations = 500
 


### PR DESCRIPTION
We used to **not** reduce dimensionality, and only limit the number of ICs to fit. 

This is an attempt to avoid running ICA on rank-deficient data: we now reduce dimensionality using PCA before the ICA step. We get rid of the option to select how many ICs to fit; the idea being that this can implicitly be controlled using the PCA step. Let's see how this performs and how many ICs it produces. If it turns out we get "too many" ICs (and ICA therefore takes too long / doesn't converge), we should add the previous option back in, in addition to this new one.
