### PR TITLE
Don't load reference run if we're not going to maxfilter anyway

### DIFF
--- a/scripts/preprocessing/01-import_and_maxfilter.py
+++ b/scripts/preprocessing/01-import_and_maxfilter.py
@@ -278,15 +278,18 @@ def run_maxwell_filter(subject, session=None):
                                                root=config.deriv_root,
                                                check=False)
 
-    # Load dev_head_t and digitization points from reference run.
+    # Load dev_head_t and digitization points from MaxFilter reference run.
     # Re-use in all runs and for processing empty-room recording.
-    reference_run = config.get_mf_reference_run()
-    # XXX Loading info would suffice!
-    bids_path_in.update(run=reference_run)
-    raw = load_data(bids_path_in)
-    dev_head_t = raw.info['dev_head_t']
-    dig = raw.info['dig']
-    del reference_run, raw
+    if config.use_maxwell_filter:
+        reference_run = config.get_mf_reference_run()
+        msg = f'Loading reference run: {reference_run}.'
+        logger.info(gen_log_message(message=msg, step=1, subject=subject,
+                                    session=session))
+        bids_path_in.update(run=reference_run)
+        info = mne.io.read_info(bids_path_in.fpath)
+        dev_head_t = info['dev_head_t']
+        dig = info['dig']
+        del reference_run, info
 
     for run_idx, run in enumerate(config.get_runs()):
         bids_path_in.update(run=run)


### PR DESCRIPTION
We were unnecessarily loading data twice when processing ERP-CORE.

This also makes it such that we only read `info` and not the entire data of the reference run.