### PR TITLE
Add back options for specifying Elekta fine-calib and cross-talk files

### DIFF
--- a/config.py
+++ b/config.py
@@ -451,6 +451,34 @@ runs. If ``None``, pick the first run.
     ```
 """
 
+mf_cal_fname: Optional[str] = None
+"""
+warning:
+     This parameter should only be used for BIDS datasets that don't store
+     the fine-calibration file
+     [according to BIDS](https://bids-specification.readthedocs.io/en/stable/99-appendices/06-meg-file-formats.html#cross-talk-and-fine-calibration-files).
+Path to the Maxwell Filter calibration file. If None the recommended
+location is used.
+???+ example "Example"
+    ```python
+    mf_cal_fname = '/path/to/your/file/calibration_cal.dat'
+    ```
+"""
+
+mf_ctc_fname: Optional[str] = None
+"""
+Path to the Maxwell Filter cross-talk file. If None the recommended
+location is used.
+warning:
+     This parameter should only be used for BIDS datasets that don't store
+     the cross-talk file
+     [according to BIDS](https://bids-specification.readthedocs.io/en/stable/99-appendices/06-meg-file-formats.html#cross-talk-and-fine-calibration-files).
+???+ example "Example"
+    ```python
+    mf_ctc_fname = '/path/to/your/file/crosstalk_ct.fif'
+    ```
+"""
+
 ###############################################################################
 # STIMULATION ARTIFACT
 # --------------------

--- a/docs/source/settings/preprocessing/maxfilter.md
+++ b/docs/source/settings/preprocessing/maxfilter.md
@@ -2,3 +2,5 @@
 ::: config.mf_st_duration
 ::: config.mf_head_origin
 ::: config.mf_reference_run
+::: config.mf_cal_fname
+::: config.mf_ctc_fname

--- a/scripts/preprocessing/01-import_and_maxfilter.py
+++ b/scripts/preprocessing/01-import_and_maxfilter.py
@@ -31,6 +31,7 @@ https://github.com/bids-standard/bids-specification/pull/265
 
 import itertools
 import logging
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -48,25 +49,39 @@ logger = logging.getLogger('mne-study-template')
 
 
 def get_mf_cal_fname(subject, session):
-    mf_cal_fpath = BIDSPath(subject=subject,
-                            session=session,
-                            suffix='meg',
-                            datatype='meg',
-                            root=config.bids_root).meg_calibration_fpath
-    if mf_cal_fpath is None:
-        raise ValueError('Could not find Maxwell Filter Calibration file.')
+    if config.mf_cal_fname is None:
+        mf_cal_fpath = BIDSPath(subject=subject,
+                                session=session,
+                                suffix='meg',
+                                datatype='meg',
+                                root=config.bids_root).meg_calibration_fpath
+        if mf_cal_fpath is None:
+            raise ValueError('Could not find Maxwell Filter Calibration '
+                             'file.')
+    else:
+        mf_cal_fpath = Path(config.mf_cal_fname)
+        if not mf_cal_fpath.exists():
+            raise ValueError(f'Could not find Maxwell Filter Calibration '
+                             f'file at {str(mf_cal_fpath)}.')
 
     return mf_cal_fpath
 
 
 def get_mf_ctc_fname(subject, session):
-    mf_ctc_fpath = BIDSPath(subject=subject,
-                            session=session,
-                            suffix='meg',
-                            datatype='meg',
-                            root=config.bids_root).meg_crosstalk_fpath
-    if mf_ctc_fpath is None:
-        raise ValueError('Could not find Maxwell Filter cross-talk file.')
+    if config.mf_ctc_fname is None:
+        mf_ctc_fpath = BIDSPath(subject=subject,
+                                session=session,
+                                suffix='meg',
+                                datatype='meg',
+                                root=config.bids_root).meg_crosstalk_fpath
+        if mf_ctc_fpath is None:
+            raise ValueError('Could not find Maxwell Filter cross-talk '
+                             'file.')
+    else:
+        mf_ctc_fpath = Path(config.mf_cal_fname)
+        if not mf_ctc_fpath.exists():
+            raise ValueError(f'Could not find Maxwell Filter cross-talk '
+                             f'file at {str(mf_ctc_fpath)}.')
 
     return mf_ctc_fpath
 


### PR DESCRIPTION
To support older BIDS datasets.

cc @agramfort